### PR TITLE
feat(health): two-phase home+session probe with adaptive wait

### DIFF
--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -53,12 +53,18 @@ jobs:
 
       - name: Run health probe
         id: probe
-        # DESIGNER_PROBE_PROJECT_URL is the "canary" project the probe opens
-        # before running session-state anchors. It must be a project the user
-        # commits to keeping around (named "designer smoke test" today). If it
-        # gets deleted, the probe will catch it via session anchors that no
-        # longer find the chat composer / share dropdown, which is the signal
-        # to pick a new canary.
+        # DESIGNER_PROBE_PROJECT_URL is the "canary" project for session-state
+        # anchors. The probe opens it after the home-phase pass so session.*
+        # / share.* anchors get exercised. It must be a project the user
+        # commits to keeping around (named "designer smoke test" today).
+        #
+        # To swap canaries:
+        #   1. Create a fresh project on claude.ai/design with stable content.
+        #   2. Open one file in it so the htmlViewer anchor lands.
+        #   3. Replace the URL below + commit + `gh workflow run daily-health.yml`
+        #      to verify green before the next scheduled run.
+        # If the canary 404s or vanishes mid-cycle, session anchors fail loudly
+        # — that's the signal to swap.
         env:
           DESIGNER_PROBE_PROJECT_URL: https://claude.ai/design/p/72e73856-7b63-4aed-b95a-caca5e3c0e05
         run: npm run -s probe:health

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -10,13 +10,23 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
-import { createBrowser } from '../browser.ts';
-import { runHealth } from '../ui-anchors.ts';
+import { createBrowser, type Browser } from '../browser.ts';
+import { runHealth, type ProbeResult } from '../ui-anchors.ts';
 import { REPO_ROOT } from '../repo-root.ts';
 
 const CDP_PORT = process.env.DESIGNER_CDP || '9222';
 const CHROME_PROFILE = path.join(os.homedir(), '.chrome-designer-profile');
 const CHROME_APP = '/Applications/Google Chrome.app';
+
+// Two-phase probe targets. Home covers home.* anchors + any-state anchors;
+// session covers session.* / share.* anchors + any-state again (we concatenate
+// rather than dedup so a state-sensitive regression in either phase shows up
+// loudly). 15s adaptive wait — claude.ai/design's SPA usually paints in 2-4s;
+// 15s is the runner-cold-load ceiling before we proceed and let anchors fail.
+const HOME_URL = 'https://claude.ai/design';
+const HOME_READY_SEL = '[data-testid="project-creator"]';
+const SESSION_READY_SEL = '[data-testid="chat-composer-input"]';
+const BROWSER_TIMEOUT_MS = 15_000;
 
 interface DoctorRun {
   exitCode: number;
@@ -99,11 +109,25 @@ async function ensureCdp(): Promise<CdpStatus> {
   return { alive: false, attemptedRestart: true, detail: final.detail };
 }
 
-async function maybeSnapshot(): Promise<{ url: string; htmlBytes: number; screenshotPath?: string } | null> {
+async function adaptiveWait(browser: Browser, sel: string, label: string): Promise<void> {
+  // Wraps agent-browser `wait <selector>` (driven by AGENT_BROWSER_DEFAULT_TIMEOUT
+  // = BROWSER_TIMEOUT_MS). On timeout we log + proceed — downstream anchor
+  // checks will fail loudly with their own detail strings, which is more
+  // useful than aborting the whole run on a slow paint.
+  try {
+    await browser.waitFor(sel);
+  } catch (e) {
+    console.log(`[ci-health] ${label} ready-selector ${sel} not seen within ${BROWSER_TIMEOUT_MS}ms — proceeding (${(e as Error).message})`);
+  }
+}
+
+async function maybeSnapshot(browser: Browser): Promise<{ url: string; htmlBytes: number; screenshotPath?: string } | null> {
   // Only fired when health regressed — gives a human enough state to diagnose
   // a Claude Design selector drift without us having to ssh into the runner.
+  // In two-phase mode this captures whichever page Chrome ended on (session
+  // when probeUrl is set, home otherwise). Consult `health.results[].phase`
+  // to know which phase a specific failure came from.
   try {
-    const browser = createBrowser({ session: 'designer-default' });
     const url = (await browser.url().catch(() => '')) || '';
     const html = await browser.evalValue<string>('document.documentElement.outerHTML').catch(() => '');
     const dir = path.join(REPO_ROOT, 'artifacts', 'health', todayUtc());
@@ -149,39 +173,59 @@ async function main(): Promise<void> {
 
   const doctor = runDoctor();
 
-  const browser = createBrowser({ session: 'designer-default' });
+  const browser = createBrowser({ session: 'designer-default', timeoutMs: BROWSER_TIMEOUT_MS });
 
-  // Optional: navigate into a "canary" project before probing so the
-  // session-state anchors (chat composer, share dropdown, handoff menu,
-  // file-list scrape) get exercised. Without this, those 10 anchors skip
-  // because the runner sits on the home page. Workflow sets
-  // DESIGNER_PROBE_PROJECT_URL to a project the user commits to keeping
-  // around — if it 404s or vanishes, the probe will catch that as a hard
-  // signal that the canary needs replacing.
+  // Phase 1 — home page. Covers home.* anchors + the one `any`-state anchor
+  // (pattern.sessionUrl). Always runs; the home page is reachable without a
+  // canary project, and home-state regressions are exactly what today's
+  // single-phase probe was missing.
+  let homeNav: { target: string; landedOn: string; error?: string } | null = null;
+  try {
+    await browser.open(HOME_URL);
+    await adaptiveWait(browser, HOME_READY_SEL, 'home');
+    const landedOn = (await browser.url().catch(() => '')) || '';
+    homeNav = { target: HOME_URL, landedOn };
+    console.log(`[ci-health] navigated to home — landed=${landedOn}`);
+  } catch (e) {
+    homeNav = { target: HOME_URL, landedOn: '', error: (e as Error).message };
+    console.log(`[ci-health] home navigation failed — ${(e as Error).message}; home anchors will fail loudly`);
+  }
+  const homeResults = await runHealth(browser, { phase: 'home' });
+
+  // Phase 2 — session (canary project). Covers session.* / share.* anchors
+  // + the `any`-state anchor again. Only runs when DESIGNER_PROBE_PROJECT_URL
+  // is set. Workflow sets it to a project the user commits to keeping
+  // around; if it 404s or vanishes, session anchors fail loudly which is
+  // the signal to pick a new canary.
   const probeUrl = process.env.DESIGNER_PROBE_PROJECT_URL;
-  let navigated: { target: string; landedOn: string; error?: string } | null = null;
+  let sessionNav: { target: string; landedOn: string; error?: string } | null = null;
+  let sessionResults: ProbeResult[] = [];
   if (probeUrl) {
     try {
       await browser.open(probeUrl);
-      await new Promise((r) => setTimeout(r, 3000));
+      await adaptiveWait(browser, SESSION_READY_SEL, 'session');
       const landedOn = (await browser.url().catch(() => '')) || '';
-      navigated = { target: probeUrl, landedOn };
+      sessionNav = { target: probeUrl, landedOn };
       console.log(`[ci-health] navigated to canary — landed=${landedOn}`);
     } catch (e) {
-      navigated = { target: probeUrl, landedOn: '', error: (e as Error).message };
-      console.log(`[ci-health] canary navigation failed — ${(e as Error).message}; continuing with home-state probe`);
+      sessionNav = { target: probeUrl, landedOn: '', error: (e as Error).message };
+      console.log(`[ci-health] canary navigation failed — ${(e as Error).message}; session anchors will fail loudly`);
     }
+    sessionResults = await runHealth(browser, { phase: 'session' });
+  } else {
+    console.log('[ci-health] DESIGNER_PROBE_PROJECT_URL unset — skipping session phase');
   }
 
-  const results = await runHealth(browser);
-  const counts = results.reduce<Record<string, number>>((acc, r) => {
-    acc[r.status] = (acc[r.status] || 0) + 1;
-    return acc;
-  }, {});
-  const fail = results.some((r) => r.status === 'fail');
+  const results: ProbeResult[] = [...homeResults, ...sessionResults];
+  const counts = {
+    ok: results.filter((r) => r.status === 'ok').length,
+    fail: results.filter((r) => r.status === 'fail').length,
+    skip: results.filter((r) => r.status === 'skip').length
+  };
+  const fail = counts.fail > 0;
   const url = (await browser.url().catch(() => '')) || '';
 
-  const diag = fail ? await maybeSnapshot() : null;
+  const diag = fail ? await maybeSnapshot(browser) : null;
 
   const payload = {
     ok: !fail,
@@ -189,11 +233,15 @@ async function main(): Promise<void> {
     finishedAt: new Date().toISOString(),
     designerVersion: pkgVersion(),
     chromeUrl: url,
-    canary: navigated,
+    // `canary` retains its V1 shape (session-navigation record) for back-compat
+    // with the drift PR body + any existing artifact reader. The home-phase
+    // navigation is captured in `homeNav` alongside it.
+    canary: sessionNav,
+    homeNav,
     doctor,
     health: {
       ok: !fail,
-      counts: { ok: counts['ok'] || 0, fail: counts['fail'] || 0, skip: counts['skip'] || 0 },
+      counts,
       results
     },
     diagnostics: diag
@@ -205,7 +253,7 @@ async function main(): Promise<void> {
   fs.writeFileSync(outFile, JSON.stringify(payload, null, 2));
 
   // One-line summary for the workflow log.
-  const summary = `[ci-health] ${payload.ok ? 'OK' : 'FAIL'} — health ${counts['ok'] || 0} ok / ${counts['fail'] || 0} fail / ${counts['skip'] || 0} skip · doctor exit ${doctor.exitCode} · v${payload.designerVersion}`;
+  const summary = `[ci-health] ${payload.ok ? 'OK' : 'FAIL'} — health ${counts.ok} ok / ${counts.fail} fail / ${counts.skip} skip · doctor exit ${doctor.exitCode} · v${payload.designerVersion}`;
   console.log(summary);
   if (fail) {
     const failed = results.filter((r) => r.status === 'fail').map((r) => `  ${r.id} — ${r.detail || r.description}`);

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -7,6 +7,7 @@ import type { Browser } from './browser.ts';
 export type AnchorCategory = 'home' | 'session' | 'share' | 'pattern';
 export type AnchorState = 'home' | 'session' | 'any';
 export type ProbeStatus = 'ok' | 'fail' | 'skip';
+export type ProbePhase = 'home' | 'session';
 
 export interface ProbeResult {
   id: string;
@@ -15,6 +16,11 @@ export interface ProbeResult {
   requires: AnchorState;
   status: ProbeStatus;
   detail?: string;
+  // Present only when runHealth was invoked with an explicit `opts.phase` —
+  // tags which navigation state the result was captured in. `any`-anchors
+  // probe in both phases, so the same id may appear twice with different
+  // phase tags.
+  phase?: ProbePhase;
 }
 
 interface AnchorDef {
@@ -250,9 +256,45 @@ export const UI_ANCHORS: AnchorDef[] = [
 
 export async function runHealth(
   browser: Browser,
-  opts: { sessionProbeUrl?: string } = {}
+  opts: { phase?: ProbePhase } = {}
 ): Promise<ProbeResult[]> {
   const currentUrl = (await browser.url().catch(() => '')) || '';
+
+  // When `opts.phase` is supplied the caller has already navigated to the
+  // matching surface — filter strictly by that phase, tag every result with
+  // it, and suppress skips (a `home`-only anchor probed during a `session`
+  // phase isn't a skip-with-detail, it's just not part of this phase's run).
+  // When omitted, fall back to URL-inferred state for back-compat with
+  // single-phase callers (cli.ts `designer health`).
+  if (opts.phase) {
+    const phase = opts.phase;
+    const results: ProbeResult[] = [];
+    for (const a of UI_ANCHORS) {
+      const applicable =
+        a.requires === 'any' ||
+        (phase === 'home' && a.requires === 'home') ||
+        (phase === 'session' && a.requires === 'session');
+      if (!applicable) continue;
+      const base = {
+        id: a.id,
+        category: a.category,
+        description: a.description,
+        requires: a.requires,
+        phase
+      };
+      try {
+        const r = await a.check(browser, currentUrl);
+        results.push({ ...base, status: r.ok ? 'ok' : 'fail', detail: r.detail });
+      } catch (e) {
+        results.push({ ...base, status: 'fail', detail: `threw: ${(e as Error).message}` });
+      }
+    }
+    return results;
+  }
+
+  // Legacy URL-inferred path. Single-phase callers see the same behavior as
+  // before — skips emitted for anchors that don't match the inferred state,
+  // no `phase` field on results.
   const inSession = /\/design\/p\/[a-f0-9-]+/i.test(currentUrl);
   const onHome = /\/design\/?$/.test(currentUrl) || currentUrl.endsWith('/design');
   const state: 'home' | 'session' | 'other' = inSession ? 'session' : onHome ? 'home' : 'other';


### PR DESCRIPTION
## Summary

Today the daily-health probe lands Chrome in the canary project and runs `runHealth(browser)` once; the 7 `home.*` anchors skip because the URL-inferred state is `session`. Coverage is 11/18. This PR extends `runHealth` with an opt-in phase argument and refactors the orchestrator to drive home → session navigation in sequence, so every anchor gets exercised every day.

Task 1 of a two-PR effort (Task 2 = LLM-in-the-loop auto-heal on probe failure, per issue #17).

## Key Changes

### Features
- **`runHealth` extension** (`ui-anchors.ts`): new optional `opts.phase: 'home' | 'session'`. When supplied, anchors filter strictly by phase (home: `home`+`any`; session: `session`+`any`), skips are suppressed, every result is tagged with the phase. When omitted, the function falls through to the existing URL-inferred path — `cli.ts`'s `designer health` is unchanged.
- **Two-phase orchestration** (`scripts/ci-health.ts`): home (`https://claude.ai/design`) → adaptive wait for `[data-testid="project-creator"]` → `runHealth({ phase: 'home' })`; then (if `DESIGNER_PROBE_PROJECT_URL` is set) canary URL → adaptive wait for `[data-testid="chat-composer-input"]` → `runHealth({ phase: 'session' })`. Results concatenate; `pattern.*` (`requires: 'any'`) runs in both phases by design so a state-sensitive regression in either phase surfaces loudly.
- **Adaptive wait**: `setTimeout(3000)` ceiling replaced with `browser.waitFor(selector)` backed by a 15s default timeout. Fast paints (2-4s) return immediately; slow cold loads no longer get cut short; a missed selector falls through to anchor-level fail detail instead of aborting the run.

### Docs
- **Canary-swap procedure** (`.github/workflows/daily-health.yml`): expanded comment near `DESIGNER_PROBE_PROJECT_URL` explaining what the canary is, how to swap it (create stable project → open a file → replace URL → `workflow_dispatch` to verify), and the failure-mode signal that prompts a swap.

### Cleanup
- Removed the dead `opts.sessionProbeUrl` parameter from `runHealth` (no caller referenced it).

## Technical Context

- **`PhasedProbeResult` vs new field**: chose `phase?: ProbePhase` as an optional field on `ProbeResult` (rather than a discriminated extension type) because the dual-path API gives this the cleanest TypeScript shape — phased callers always populate it, legacy callers never do, consumers narrow with `r.phase === 'home'` discriminants.
- **`any` anchors in both phases**: per plan, the one `requires: 'any'` anchor (`pattern.sessionUrl`) runs in both phases. Slight JSON duplication (~1 entry) traded for guaranteed detection of state-sensitive URL-pattern regressions.
- **Snapshot heuristic**: `maybeSnapshot()` now takes a shared browser instance and captures whichever page Chrome ended on. If a home anchor fails AND session phase ran, the snapshot is of session — V1 limitation, documented inline. Auto-heal (Task 2) consumes `health.results[].phase` to know which phase a failure came from regardless of snapshot.
- **JSON shape**: `health.results[]` gains `phase`; top-level adds `homeNav`; existing `canary` field keeps shape (now = session-nav specifically) for drift-PR back-compat.

## Acceptance

- [x] **Typecheck** — `tsc --noEmit` green ([ci run](https://github.com/pro-vi/designer/actions/runs/25794596875/job/75768522421))
- [x] **Docker clean-room install smoke** — `designer --help`, `designer health --help`, `designer doctor` all exit cleanly in `node:20` container ([ci run](https://github.com/pro-vi/designer/actions/runs/25794596875/job/75768564438))
- [x] **Legacy `designer health` CLI preserved** — `cli.ts:199` calls `runHealth(browser)` with no opts; verified by code review that the URL-inferred branch is unchanged (no skip-emission change for legacy callers, no phase tagging).
- [x] **Adaptive wait fall-through** — `adaptiveWait()` in `scripts/ci-health.ts` wraps `browser.waitFor` in try/catch; on timeout it logs and proceeds (no run abort).
- [ ] **Live-fire: `workflow_dispatch` of `daily-health.yml` post-merge** — expected to produce `counts.ok >= 19` across ~20 entries (7 home + 11 session-required + 1 `any` x 2 phases = 20; `pattern.fileQueryParam` is `ok`-by-design). Self-hosted Mac mini runs the actual probe with live CDP on `:9222`; this cannot be verified pre-merge from this branch. **Run after merge**: `gh workflow run daily-health.yml`.

## Plan reference

- Plan: `~/.claude/plans/tmp-agent-brief-health-autoheal-md-iridescent-mccarthy.md` (U1–U3)
- Origin brief: `/tmp/agent-brief-health-autoheal.md`
- Issue #17 (Task 2 follow-up): not closed by this PR

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)