### PR TITLE
feat(auto-heal): LLM-in-the-loop selector recovery on probe failure

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -21,11 +21,14 @@ permissions:
 
 jobs:
   heal:
-    # Only fire on the failure conclusion. Successful daily-health runs
-    # mean nothing regressed, so there's nothing to heal. Skipped /
-    # cancelled / startup_failure conclusions are infra issues, not
-    # selector drift — auto-heal would be guessing about state it can't see.
-    if: github.event.workflow_run.conclusion == 'failure'
+    # Fire on every daily-health completion regardless of conclusion.
+    # daily-health.yml marks the probe step `continue-on-error: true`, so
+    # the workflow's roll-up conclusion is `success` even when the probe
+    # fails — gating on `workflow_run.conclusion` here would never see a
+    # probe failure. `auto-heal.ts triage` reads the artifact and the
+    # streak file to decide; on green days it emits `action=skip` and the
+    # heal step is skipped via the per-step `if` below. Cost: ~30s of
+    # runner time on green days for triage + artifact download.
     name: propose ui-anchor patch on probe failure
     # Self-hosted so we can re-run the probe against the live CDP Chrome
     # (same runner that ran daily-health). Datacenter runners can't reach

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -86,7 +86,12 @@ jobs:
         if: steps.triage.outputs.action == 'heal'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Either credential is sufficient — auto-heal.ts prefers OAuth when
+          # both are set. ANTHROPIC_API_KEY is per-token metered billing;
+          # CLAUDE_CODE_OAUTH_TOKEN is Claude Pro/Max subscription quota
+          # (installed by the official Claude Code GitHub App, see #20).
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Re-probe needs the same canary the original run probed. Keep this
           # mirror of daily-health.yml's value in sync if you swap canaries
           # — both workflows reference the same project URL by convention.

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -1,0 +1,133 @@
+name: auto-heal
+
+# Fires after daily-health concludes. On failure, downloads the failing
+# probe's artifact, runs `scripts/auto-heal.ts triage` to pick a single
+# anchor with streak >= 2 (and not in 7-day cooldown), then `heal` it via
+# LLM inference + local re-probe. If green after patch, opens a PR for
+# human review. Auto-heal PRs are NEVER auto-merged — that's an explicit
+# constraint from issue #17.
+
+on:
+  workflow_run:
+    workflows: ["daily-health"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  # Required for actions/download-artifact@v4 to fetch artifacts from a
+  # different workflow run (the triggering daily-health run).
+  actions: read
+
+jobs:
+  heal:
+    # Only fire on the failure conclusion. Successful daily-health runs
+    # mean nothing regressed, so there's nothing to heal. Skipped /
+    # cancelled / startup_failure conclusions are infra issues, not
+    # selector drift — auto-heal would be guessing about state it can't see.
+    if: github.event.workflow_run.conclusion == 'failure'
+    name: propose ui-anchor patch on probe failure
+    # Self-hosted so we can re-run the probe against the live CDP Chrome
+    # (same runner that ran daily-health). Datacenter runners can't reach
+    # the signed-in Chrome profile.
+    runs-on: [self-hosted, macOS, designer-health]
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout at triggering SHA
+        uses: actions/checkout@v4
+        with:
+          # Run against the exact commit daily-health probed. If main has
+          # advanced since, the probe artifact reflects the old code and
+          # the patch needs to land on the same base — peter-evans will
+          # rebase as needed when opening the PR.
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Ensure labels exist (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create auto-heal \
+            --color B7E4C7 \
+            --description "LLM-proposed selector recovery from daily-health drift" \
+            2>/dev/null || true
+          gh label create wholesale-redesign-suspected \
+            --color FFB4A2 \
+            --description ">=5 anchors regressed at once — needs human triage" \
+            2>/dev/null || true
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Download health artifact from triggering run
+        # Cross-workflow artifact download. `run-id` + `github-token` are
+        # what differentiates this from a same-run download.
+        uses: actions/download-artifact@v4
+        with:
+          name: health-${{ github.event.workflow_run.id }}
+          path: artifacts/health/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install
+        run: npm ci --no-audit --no-fund
+
+      - name: Triage candidate anchor
+        id: triage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run -s auto-heal -- triage
+
+      - name: Heal selected anchor
+        id: heal
+        if: steps.triage.outputs.action == 'heal'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Re-probe needs the same canary the original run probed. Keep this
+          # mirror of daily-health.yml's value in sync if you swap canaries
+          # — both workflows reference the same project URL by convention.
+          DESIGNER_PROBE_PROJECT_URL: https://claude.ai/design/p/72e73856-7b63-4aed-b95a-caca5e3c0e05
+        run: npm run -s auto-heal -- heal "${{ steps.triage.outputs.anchor-id }}"
+
+      - name: Open auto-heal PR
+        if: steps.heal.outputs.patched == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: health/auto-heal-${{ steps.heal.outputs.anchor-id }}-${{ steps.heal.outputs.date }}
+          base: main
+          add-paths: |
+            ui-anchors.ts
+          commit-message: |
+            chore(ui-anchors): auto-heal ${{ steps.heal.outputs.anchor-id }}
+
+            Replaces selector for ${{ steps.heal.outputs.anchor-id }} from
+            `${{ steps.heal.outputs.old-selector }}` to `${{ steps.heal.outputs.new-selector }}`.
+            LLM confidence: ${{ steps.heal.outputs.confidence }}. Re-probe green.
+          title: "chore(ui-anchors): auto-heal ${{ steps.heal.outputs.anchor-id }}"
+          labels: |
+            auto-heal
+          body: |
+            ## Auto-heal proposal
+
+            - **Anchor**: `${{ steps.heal.outputs.anchor-id }}`
+            - **Before**: `${{ steps.heal.outputs.old-selector }}`
+            - **After**: `${{ steps.heal.outputs.new-selector }}`
+            - **Confidence**: ${{ steps.heal.outputs.confidence }}
+            - **Local re-probe**: green after patch
+            - **Originating drift PR**: ${{ steps.heal.outputs.drift-pr-number != '' && format('#{0}', steps.heal.outputs.drift-pr-number) || '(none found)' }}
+            - **Triggered by run**: [daily-health #${{ github.event.workflow_run.id }}](${{ github.event.workflow_run.html_url }})
+
+            ### LLM rationale
+
+            > ${{ steps.heal.outputs.rationale }}
+
+            ---
+
+            **Human review required.** This PR is NOT auto-merged. Verify the
+            new selector matches the intended element before merging — auto-
+            heal validates that the *anchor probes green*, not that the
+            selector targets the *right* DOM node.

--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -51,6 +51,23 @@ jobs:
         id: stamp
         run: echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
 
+      # actions/checkout creates a clean clone each run, so the streak file
+      # written by ci-health.ts (artifacts/health/streak.json) doesn't
+      # persist across runs by default. Without persistence the N=2 streak
+      # gate in auto-heal never fires — every run starts fresh at 0.
+      # Restore the most recent saved copy here; save after the probe
+      # completes (whether green or fail). save-key uses run_id so each
+      # run writes its own cache entry; restore-keys falls through to the
+      # latest streak- prefix.
+      - name: Restore streak file
+        id: streak-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: artifacts/health/streak.json
+          key: streak-${{ github.run_id }}
+          restore-keys: |
+            streak-
+
       - name: Run health probe
         id: probe
         # DESIGNER_PROBE_PROJECT_URL is the "canary" project for session-state
@@ -69,6 +86,18 @@ jobs:
           DESIGNER_PROBE_PROJECT_URL: https://claude.ai/design/p/72e73856-7b63-4aed-b95a-caca5e3c0e05
         run: npm run -s probe:health
         continue-on-error: true
+
+      - name: Save streak file
+        # Always save — green runs reset streak entries to 0, and we want
+        # the auto-heal workflow + future runs to see that. `actions/cache`
+        # writes only on cache miss; the key is unique per run_id so we
+        # always get a new cache entry, and old entries age out per
+        # GitHub's cache eviction policy.
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: artifacts/health/streak.json
+          key: streak-${{ github.run_id }}
 
       - name: Upload health artifact
         if: always()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "designer",
+  "name": "@pro-vi/designer",
   "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "designer",
+      "name": "@pro-vi/designer",
       "version": "0.3.6",
       "hasInstallScript": true,
       "license": "MIT",
@@ -14,6 +14,7 @@
         "linux"
       ],
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.96.0",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "zod": "^3.23.8"
       },
@@ -27,6 +28,36 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.96.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.96.0.tgz",
+      "integrity": "sha512-KlCsODtTyb17bLUVCSDC2HtSvAbJf60sEiPEax9dInF+aDF92vS4TZJ5XD7YCQXNb1/5icYaw8Y7wMjPlIV9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -523,6 +554,12 @@
         }
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.7.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
@@ -942,6 +979,12 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -1195,6 +1238,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -1595,6 +1651,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1612,6 +1678,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -36,9 +36,11 @@
     "postinstall": "node scripts/postinstall.mjs",
     "probe": "tsx scripts/probe.ts",
     "probe:health": "tsx scripts/ci-health.ts",
+    "auto-heal": "tsx scripts/auto-heal.ts",
     "smoke": "bash scripts/install-smoke.sh"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.96.0",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "zod": "^3.23.8"
   },
@@ -50,7 +52,10 @@
   "engines": {
     "node": ">=20"
   },
-  "os": ["darwin", "linux"],
+  "os": [
+    "darwin",
+    "linux"
+  ],
   "files": [
     "dist/",
     "bin/",

--- a/scripts/anchor-patcher.ts
+++ b/scripts/anchor-patcher.ts
@@ -1,0 +1,153 @@
+// AST-driven mutator for ui-anchors.ts. Finds an anchor block by `id` and
+// rewrites the single string-literal argument to its `hasSelector(b, '<sel>')`
+// check while preserving the rest of the file byte-for-byte.
+//
+// V1 scope: only anchors whose check body has the exact concise shape
+//   check: async (b) => ({ ok: await hasSelector(b, '<sel>') })
+// are patchable. Anchors with `hasButtonMatching`, complex `evalValue` walkers,
+// or block-bodied checks (the `if (!/file=/.test(url)) return ...` guards) are
+// rejected by `canPatch` — auto-heal skips them with "complex check, V1 limit".
+// Extending the patcher to those shapes is V2 work; the small surface here
+// keeps the failure modes shallow.
+
+import ts from 'typescript';
+
+export interface AnchorMatch {
+  /** Byte offset of the string-literal node start (INCLUDING opening quote). */
+  literalStart: number;
+  /** Byte offset of the string-literal node end (EXCLUSIVE; one past closing quote). */
+  literalEnd: number;
+  /** The quote character used by the original literal: `'`, `"`, or `` ` ``. */
+  quote: "'" | '"' | '`';
+  /** Decoded (unquoted) string content. */
+  currentSelector: string;
+}
+
+export function findAnchor(source: string, id: string): AnchorMatch | null {
+  const sf = ts.createSourceFile('ui-anchors.ts', source, ts.ScriptTarget.Latest, true);
+  let result: AnchorMatch | null = null;
+
+  const visit = (node: ts.Node): void => {
+    if (result) return;
+    if (ts.isObjectLiteralExpression(node) && matchesAnchorWithId(node, id)) {
+      const checkProp = findProperty(node, 'check');
+      if (checkProp) {
+        const sel = extractSimpleHasSelectorArg(checkProp.initializer, sf);
+        if (sel) result = sel;
+      }
+      return; // don't recurse into the matched anchor
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sf);
+  return result;
+}
+
+export function canPatch(source: string, id: string): boolean {
+  return findAnchor(source, id) !== null;
+}
+
+export function patchSelector(source: string, id: string, newSelector: string): string {
+  const match = findAnchor(source, id);
+  if (!match) {
+    throw new Error(
+      `anchor-patcher: id "${id}" is not patchable — either not found or its check is not the simple hasSelector(b, '...') shape`
+    );
+  }
+  const escaped = escapeForQuote(newSelector, match.quote);
+  return (
+    source.slice(0, match.literalStart) +
+    match.quote +
+    escaped +
+    match.quote +
+    source.slice(match.literalEnd)
+  );
+}
+
+// ---- internals ----
+
+function matchesAnchorWithId(obj: ts.ObjectLiteralExpression, id: string): boolean {
+  const idProp = findProperty(obj, 'id');
+  if (!idProp) return false;
+  const init = idProp.initializer;
+  if (ts.isStringLiteralLike(init)) {
+    return init.text === id;
+  }
+  return false;
+}
+
+function findProperty(
+  obj: ts.ObjectLiteralExpression,
+  name: string
+): ts.PropertyAssignment | null {
+  for (const p of obj.properties) {
+    if (!ts.isPropertyAssignment(p)) continue;
+    const n = p.name;
+    if (ts.isIdentifier(n) && n.text === name) return p;
+    if (ts.isStringLiteral(n) && n.text === name) return p;
+  }
+  return null;
+}
+
+function extractSimpleHasSelectorArg(
+  expr: ts.Expression,
+  sf: ts.SourceFile
+): AnchorMatch | null {
+  // Required shape: async (b) => ({ ok: await hasSelector(b, '<sel>') })
+  if (!ts.isArrowFunction(expr)) return null;
+
+  let body: ts.Node = expr.body;
+  // Concise body wrapped in parens: ({ ok: ... })
+  if (ts.isParenthesizedExpression(body)) body = body.expression;
+  if (!ts.isObjectLiteralExpression(body)) return null;
+
+  // Exactly one property named `ok`.
+  if (body.properties.length !== 1) return null;
+  const okProp = body.properties[0];
+  if (!okProp || !ts.isPropertyAssignment(okProp)) return null;
+  if (!ts.isIdentifier(okProp.name) || okProp.name.text !== 'ok') return null;
+
+  const okValue = okProp.initializer;
+  if (!ts.isAwaitExpression(okValue)) return null;
+
+  const call = okValue.expression;
+  if (!ts.isCallExpression(call)) return null;
+  if (!ts.isIdentifier(call.expression) || call.expression.text !== 'hasSelector') return null;
+
+  // Args: (b, '<sel>')
+  if (call.arguments.length !== 2) return null;
+  const [arg0, arg1] = call.arguments;
+  if (!arg0 || !arg1) return null;
+  if (!ts.isIdentifier(arg0) || arg0.text !== 'b') return null;
+  if (!ts.isStringLiteralLike(arg1)) return null;
+
+  const raw = arg1.getText(sf);
+  const quote = detectQuote(raw);
+  if (!quote) return null;
+
+  return {
+    literalStart: arg1.getStart(sf),
+    literalEnd: arg1.getEnd(),
+    quote,
+    currentSelector: arg1.text
+  };
+}
+
+function detectQuote(literalText: string): "'" | '"' | '`' | null {
+  const first = literalText[0];
+  if (first === "'" || first === '"' || first === '`') return first;
+  return null;
+}
+
+function escapeForQuote(s: string, quote: "'" | '"' | '`'): string {
+  // Backslash always escapes; the specific quote character escapes; for
+  // backticks we also escape `${` to avoid accidental template substitution.
+  let out = s.replace(/\\/g, '\\\\');
+  if (quote === "'") out = out.replace(/'/g, "\\'");
+  else if (quote === '"') out = out.replace(/"/g, '\\"');
+  else {
+    out = out.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+  }
+  return out;
+}

--- a/scripts/auto-heal.ts
+++ b/scripts/auto-heal.ts
@@ -337,10 +337,20 @@ function loadScreenshotBase64(date: string): string | null {
 }
 
 async function heal(anchorId: string): Promise<void> {
-  if (!process.env.ANTHROPIC_API_KEY) {
-    console.log('[auto-heal heal] ANTHROPIC_API_KEY unset — exiting without patch');
+  // Two auth paths: API key (x-api-key header, metered per-token billing) OR
+  // OAuth token via Claude Pro/Max subscription (Bearer header, subscription
+  // quota). CLAUDE_CODE_OAUTH_TOKEN is the secret name the official Claude
+  // Code Action installs; pass it as authToken to the SDK. The SDK supports
+  // both via separate constructor options — apiKey wins if both are set.
+  const apiKey = process.env.ANTHROPIC_API_KEY ?? undefined;
+  const authToken =
+    process.env.ANTHROPIC_AUTH_TOKEN ?? process.env.CLAUDE_CODE_OAUTH_TOKEN ?? undefined;
+  if (!apiKey && !authToken) {
+    console.log(
+      '[auto-heal heal] no Anthropic credential (need ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN) — exiting without patch'
+    );
     ghOutput('patched', 'false');
-    ghOutput('reason', 'no-api-key');
+    ghOutput('reason', 'no-credential');
     return;
   }
 
@@ -431,7 +441,7 @@ async function heal(anchorId: string): Promise<void> {
     }
   };
 
-  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  const client = new Anthropic({ apiKey, authToken });
   const userContent: Anthropic.MessageParam['content'] = [{ type: 'text', text: promptText }];
   if (screenshot) {
     userContent.unshift({

--- a/scripts/auto-heal.ts
+++ b/scripts/auto-heal.ts
@@ -1,0 +1,635 @@
+#!/usr/bin/env -S node --import tsx
+// LLM-in-the-loop selector recovery. Triggered by `.github/workflows/auto-heal.yml`
+// on daily-health failure. Two subcommands:
+//
+//   auto-heal triage
+//     - Reads the latest artifact JSON. Bails on infra failures
+//       (reason === 'cdp-unreachable'). Reads streak.json and picks one
+//       eligible candidate (streak >= 2, AST-patchable, not in 7-day cooldown).
+//       If >= 5 anchors regressed at once, comments wholesale-redesign on the
+//       drift PR and bails. Emits step outputs telling the workflow whether
+//       to proceed.
+//
+//   auto-heal heal <anchor-id>
+//     - Reads the anchor block + HTML snapshot + screenshot. Calls
+//       Anthropic API (claude-opus-4-7, tool-use). Bails on low confidence
+//       or brittle selectors. Patches ui-anchors.ts. Re-runs the local
+//       probe. If the patched anchor flips to ok, emits the step outputs
+//       the workflow uses to open a PR. Otherwise reverts the patch.
+//
+// All failure modes exit 0 — auto-heal is best-effort. The drift PR opened
+// by daily-health stays as the human-readable diagnostic regardless.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync, execSync } from 'node:child_process';
+import Anthropic from '@anthropic-ai/sdk';
+import { REPO_ROOT } from '../repo-root.ts';
+import { canPatch, findAnchor, patchSelector } from './anchor-patcher.ts';
+
+const HEALTH_DIR = path.join(REPO_ROOT, 'artifacts', 'health');
+const STREAK_PATH = path.join(HEALTH_DIR, 'streak.json');
+const ANCHORS_PATH = path.join(REPO_ROOT, 'ui-anchors.ts');
+const STREAK_THRESHOLD = 2;
+const WHOLESALE_THRESHOLD = 5;
+const COOLDOWN_DAYS = 7;
+const CONFIDENCE_THRESHOLD = 0.7;
+const ANTHROPIC_MODEL = 'claude-opus-4-7';
+
+// Priority: session anchors regressing breaks the canary loop hardest, so
+// heal them first. Pattern anchors are URL-shape — usually low-yield to
+// auto-heal but possible. Home last because home regressions don't block
+// session-state probing.
+const PRIORITY: Array<'session' | 'home' | 'pattern' | 'share'> = [
+  'session',
+  'share',
+  'home',
+  'pattern'
+];
+
+interface ProbeResult {
+  id: string;
+  category: 'home' | 'session' | 'share' | 'pattern';
+  description: string;
+  requires: 'home' | 'session' | 'any';
+  status: 'ok' | 'fail' | 'skip';
+  detail?: string;
+  phase?: 'home' | 'session';
+}
+
+interface ArtifactJson {
+  ok: boolean;
+  reason?: string;
+  health?: {
+    ok: boolean;
+    counts: { ok: number; fail: number; skip: number };
+    results: ProbeResult[];
+  };
+  diagnostics?: { url: string; htmlBytes: number; screenshotPath?: string } | null;
+  canary?: { target: string; landedOn: string; error?: string } | null;
+  homeNav?: { target: string; landedOn: string; error?: string } | null;
+}
+
+interface ProposeSelectorInput {
+  newSelector: string;
+  confidence: number;
+  rationale: string;
+}
+
+function ghOutput(key: string, value: string): void {
+  const target = process.env.GITHUB_OUTPUT;
+  if (!target) {
+    console.log(`[auto-heal] (no GITHUB_OUTPUT) ${key}=${value}`);
+    return;
+  }
+  // Multi-line values need heredoc form. Single-line use key=value.
+  if (value.includes('\n')) {
+    const delim = `EOF_${Math.random().toString(36).slice(2, 10)}`;
+    fs.appendFileSync(target, `${key}<<${delim}\n${value}\n${delim}\n`);
+  } else {
+    fs.appendFileSync(target, `${key}=${value}\n`);
+  }
+}
+
+function latestArtifact(): { path: string; date: string; data: ArtifactJson } | null {
+  if (!fs.existsSync(HEALTH_DIR)) return null;
+  const entries = fs
+    .readdirSync(HEALTH_DIR)
+    .filter((f) => /^\d{4}-\d{2}-\d{2}\.json$/.test(f))
+    .sort()
+    .reverse();
+  for (const name of entries) {
+    const p = path.join(HEALTH_DIR, name);
+    try {
+      const data = JSON.parse(fs.readFileSync(p, 'utf8')) as ArtifactJson;
+      return { path: p, date: name.replace(/\.json$/, ''), data };
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+function loadStreak(): Record<string, number> {
+  if (!fs.existsSync(STREAK_PATH)) return {};
+  try {
+    const raw = JSON.parse(fs.readFileSync(STREAK_PATH, 'utf8')) as unknown;
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+    const out: Record<string, number> = {};
+    for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+      if (typeof v === 'number' && Number.isFinite(v) && v >= 0) out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function gh(args: string[], opts: { quiet?: boolean } = {}): string {
+  const r = spawnSync('gh', args, { encoding: 'utf8', env: process.env });
+  if (r.status !== 0) {
+    if (!opts.quiet) console.log(`[auto-heal] gh ${args.join(' ')} exited ${r.status}: ${r.stderr.trim()}`);
+    return '';
+  }
+  return r.stdout;
+}
+
+function isWithinCooldown(anchorId: string): boolean {
+  // Search for any auto-heal PR (open or closed) tagged with this anchor id
+  // in the title within the cooldown window. `gh pr list --search` accepts
+  // GitHub search syntax — restrict to PRs whose title contains the id.
+  const out = gh([
+    'pr',
+    'list',
+    '--label',
+    'auto-heal',
+    '--state',
+    'all',
+    '--search',
+    `auto-heal ${anchorId} in:title`,
+    '--json',
+    'createdAt',
+    '--limit',
+    '5'
+  ]);
+  if (!out.trim()) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(out);
+  } catch {
+    return false;
+  }
+  if (!Array.isArray(parsed)) return false;
+  const cutoff = Date.now() - COOLDOWN_DAYS * 24 * 60 * 60 * 1000;
+  for (const item of parsed) {
+    if (!item || typeof item !== 'object') continue;
+    const createdAt = (item as { createdAt?: unknown }).createdAt;
+    if (typeof createdAt !== 'string') continue;
+    if (Date.parse(createdAt) >= cutoff) return true;
+  }
+  return false;
+}
+
+function findDriftPrNumber(date: string): number | null {
+  const out = gh([
+    'pr',
+    'list',
+    '--label',
+    'selectors-drift',
+    '--state',
+    'open',
+    '--search',
+    `head:health/drift-${date}`,
+    '--json',
+    'number,headRefName',
+    '--limit',
+    '5'
+  ]);
+  if (!out.trim()) return null;
+  try {
+    const arr = JSON.parse(out) as Array<{ number: number; headRefName: string }>;
+    const match = arr.find((p) => p.headRefName === `health/drift-${date}`);
+    return match ? match.number : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---- triage ----
+
+function triage(): void {
+  const artifact = latestArtifact();
+  if (!artifact) {
+    console.log('[auto-heal triage] no artifact found');
+    ghOutput('action', 'skip');
+    ghOutput('reason', 'no-artifact');
+    return;
+  }
+  const { data, date } = artifact;
+  ghOutput('date', date);
+
+  if (data.reason === 'cdp-unreachable') {
+    console.log('[auto-heal triage] artifact reason=cdp-unreachable — infra failure, skipping');
+    ghOutput('action', 'skip');
+    ghOutput('reason', 'cdp-unreachable');
+    return;
+  }
+
+  if (!data.health || !Array.isArray(data.health.results)) {
+    console.log('[auto-heal triage] artifact has no health.results');
+    ghOutput('action', 'skip');
+    ghOutput('reason', 'no-results');
+    return;
+  }
+
+  const streak = loadStreak();
+  const candidates = Object.entries(streak)
+    .filter(([, n]) => n >= STREAK_THRESHOLD)
+    .map(([id]) => id);
+
+  if (candidates.length === 0) {
+    console.log(`[auto-heal triage] no anchors at streak >= ${STREAK_THRESHOLD}`);
+    ghOutput('action', 'skip');
+    ghOutput('reason', 'below-threshold');
+    return;
+  }
+
+  if (candidates.length >= WHOLESALE_THRESHOLD) {
+    console.log(`[auto-heal triage] ${candidates.length} anchors regressed — wholesale-redesign suspected`);
+    const driftPr = findDriftPrNumber(date);
+    if (driftPr != null) {
+      const body = [
+        '## Wholesale redesign suspected',
+        '',
+        `${candidates.length} UI anchors have failed for ${STREAK_THRESHOLD}+ consecutive runs:`,
+        '',
+        ...candidates.map((id) => `- \`${id}\` (streak=${streak[id]})`),
+        '',
+        'Auto-heal **is not** opening single-anchor PRs for this — the failure pattern looks like a coordinated redesign on claude.ai/design, not isolated selector drift. A human should inspect the full snapshot before deciding which anchors to update.',
+        '',
+        `Labelled \`wholesale-redesign-suspected\` to flag in triage.`
+      ].join('\n');
+      gh(['pr', 'comment', String(driftPr), '--body', body]);
+      gh(['pr', 'edit', String(driftPr), '--add-label', 'wholesale-redesign-suspected']);
+    } else {
+      console.log('[auto-heal triage] no drift PR found for this date — wholesale message skipped');
+    }
+    ghOutput('action', 'skip');
+    ghOutput('reason', 'wholesale-redesign');
+    ghOutput('candidate-count', String(candidates.length));
+    return;
+  }
+
+  // Map id → category for priority sort
+  const byId = new Map<string, ProbeResult>();
+  for (const r of data.health.results) {
+    if (!byId.has(r.id)) byId.set(r.id, r);
+  }
+
+  // Sort candidates by priority bucket
+  const sorted = [...candidates].sort((a, b) => {
+    const ca = byId.get(a)?.category ?? 'pattern';
+    const cb = byId.get(b)?.category ?? 'pattern';
+    return PRIORITY.indexOf(ca) - PRIORITY.indexOf(cb);
+  });
+
+  const anchorsSource = fs.readFileSync(ANCHORS_PATH, 'utf8');
+
+  for (const id of sorted) {
+    if (!canPatch(anchorsSource, id)) {
+      console.log(`[auto-heal triage] ${id} — check shape not auto-patchable, skipping`);
+      continue;
+    }
+    if (isWithinCooldown(id)) {
+      console.log(`[auto-heal triage] ${id} — within ${COOLDOWN_DAYS}-day cooldown, skipping`);
+      continue;
+    }
+    console.log(`[auto-heal triage] selected ${id} (streak=${streak[id]}, category=${byId.get(id)?.category ?? 'unknown'})`);
+    ghOutput('action', 'heal');
+    ghOutput('anchor-id', id);
+    return;
+  }
+
+  console.log('[auto-heal triage] all candidates either complex or in cooldown — skipping');
+  ghOutput('action', 'skip');
+  ghOutput('reason', 'no-eligible-candidate');
+}
+
+// ---- heal ----
+
+function isBrittleSelector(sel: string): boolean {
+  // Pure structural CSS paths are too brittle to land via auto-heal. Reject
+  // selectors that lean on nth-child / nth-of-type — they're position-bound
+  // and break on tiny DOM tweaks. data-testid / role / aria-* / text-content
+  // markers are preferred and pass this filter.
+  if (/:nth-child\(|:nth-of-type\(/i.test(sel)) return true;
+  // No identifying attribute at all — pure tag+combinator path.
+  if (
+    !/\[/.test(sel) &&
+    !/data-testid/i.test(sel) &&
+    !/role=/i.test(sel) &&
+    !/aria-/i.test(sel) &&
+    !/#[\w-]/.test(sel) &&
+    !/\./.test(sel)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function loadSnapshotHtml(date: string): string {
+  const p = path.join(HEALTH_DIR, date, 'page.html');
+  if (!fs.existsSync(p)) return '';
+  const raw = fs.readFileSync(p, 'utf8');
+  // Cap at ~60KB — the prompt budget is finite and most of <head> is style/font
+  // boilerplate. The anchor selector inference cares about the rendered tree
+  // around testids, role attrs, button text — usually <body>'s first ~60KB.
+  if (raw.length <= 60_000) return raw;
+  const bodyStart = raw.search(/<body[\s>]/i);
+  if (bodyStart > 0) return raw.slice(bodyStart, bodyStart + 60_000);
+  return raw.slice(0, 60_000);
+}
+
+function loadScreenshotBase64(date: string): string | null {
+  const p = path.join(HEALTH_DIR, date, 'page.png');
+  if (!fs.existsSync(p)) return null;
+  return fs.readFileSync(p).toString('base64');
+}
+
+async function heal(anchorId: string): Promise<void> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    console.log('[auto-heal heal] ANTHROPIC_API_KEY unset — exiting without patch');
+    ghOutput('patched', 'false');
+    ghOutput('reason', 'no-api-key');
+    return;
+  }
+
+  const artifact = latestArtifact();
+  if (!artifact) {
+    console.log('[auto-heal heal] no artifact');
+    ghOutput('patched', 'false');
+    ghOutput('reason', 'no-artifact');
+    return;
+  }
+  const { date, data } = artifact;
+
+  const failed = data.health?.results.find((r) => r.id === anchorId && r.status === 'fail');
+  if (!failed) {
+    console.log(`[auto-heal heal] ${anchorId} not in failed-results — nothing to heal`);
+    ghOutput('patched', 'false');
+    ghOutput('reason', 'not-failing');
+    return;
+  }
+
+  const anchorsSource = fs.readFileSync(ANCHORS_PATH, 'utf8');
+  const match = findAnchor(anchorsSource, anchorId);
+  if (!match) {
+    console.log(`[auto-heal heal] ${anchorId} not patchable`);
+    ghOutput('patched', 'false');
+    ghOutput('reason', 'not-patchable');
+    return;
+  }
+
+  const html = loadSnapshotHtml(date);
+  const screenshot = loadScreenshotBase64(date);
+
+  const anchor = data.health?.results.find((r) => r.id === anchorId);
+  const phaseHint = failed.phase ?? anchor?.requires ?? 'unknown';
+
+  const promptText = [
+    `# Failed UI anchor`,
+    ``,
+    `**Anchor id:** \`${anchorId}\``,
+    `**Description:** ${anchor?.description ?? '(unknown)'}`,
+    `**Required state:** ${anchor?.requires ?? '(unknown)'}`,
+    `**Phase observed:** ${phaseHint}`,
+    `**Current selector:** \`${match.currentSelector}\``,
+    `**Failure detail:** ${failed.detail ?? '(no detail)'}`,
+    ``,
+    `# Anchor block (from ui-anchors.ts)`,
+    '```typescript',
+    anchorSourceBlock(anchorsSource, anchorId),
+    '```',
+    ``,
+    `# Page HTML (captured when probe failed${html.length === 60_000 ? '; truncated to 60KB' : ''})`,
+    '```html',
+    html.slice(0, 60_000),
+    '```',
+    ``,
+    `# Task`,
+    `Propose a single new CSS selector that finds the same UI element the`,
+    `original selector targeted before the regression. The selector will replace`,
+    `the string literal inside \`hasSelector(b, '...')\` in the anchor block above.`,
+    ``,
+    `Selector preferences (strict): \`data-testid\` > \`role\` > \`aria-*\` > stable id > stable class.`,
+    `Reject pure structural paths (\`div > div:nth-child(N)\`) — too brittle.`,
+    `If the right element clearly does not exist in the snapshot, return confidence < 0.5.`
+  ].join('\n');
+
+  const tool: Anthropic.Tool = {
+    name: 'propose_selector',
+    description: 'Propose a CSS selector to replace the failed UI anchor.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        newSelector: {
+          type: 'string',
+          description: 'CSS selector for the replacement DOM element (single string, no quotes).'
+        },
+        confidence: {
+          type: 'number',
+          minimum: 0,
+          maximum: 1,
+          description: '0..1. Below 0.7 will be rejected by the caller.'
+        },
+        rationale: {
+          type: 'string',
+          description: 'Why this selector matches the anchor description — what DOM evidence supports it.'
+        }
+      },
+      required: ['newSelector', 'confidence', 'rationale']
+    }
+  };
+
+  const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  const userContent: Anthropic.MessageParam['content'] = [{ type: 'text', text: promptText }];
+  if (screenshot) {
+    userContent.unshift({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: screenshot }
+    });
+  }
+
+  console.log(`[auto-heal heal] calling ${ANTHROPIC_MODEL} for ${anchorId}`);
+  let response: Anthropic.Message;
+  try {
+    response = await client.messages.create({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 2048,
+      tools: [tool],
+      tool_choice: { type: 'tool', name: 'propose_selector' },
+      system:
+        'You are a UI-anchor selector recovery agent for claude.ai/design. Given a failed UI anchor and the page HTML + screenshot at the moment of failure, propose a single replacement CSS selector. Prefer stable test markers (data-testid, role, aria-*) over structural paths.',
+      messages: [{ role: 'user', content: userContent }]
+    });
+  } catch (e) {
+    console.log(`[auto-heal heal] Anthropic API error: ${(e as Error).message}`);
+    ghOutput('patched', 'false');
+    ghOutput('reason', 'api-error');
+    return;
+  }
+
+  const toolUse = response.content.find((b): b is Anthropic.ToolUseBlock => b.type === 'tool_use');
+  if (!toolUse) {
+    console.log(`[auto-heal heal] model did not call the propose_selector tool`);
+    ghOutput('patched', 'false');
+    ghOutput('reason', 'no-tool-call');
+    return;
+  }
+  const input = toolUse.input as Partial<ProposeSelectorInput>;
+  if (
+    typeof input.newSelector !== 'string' ||
+    typeof input.confidence !== 'number' ||
+    typeof input.rationale !== 'string'
+  ) {
+    console.log(`[auto-heal heal] propose_selector input malformed: ${JSON.stringify(input)}`);
+    ghOutput('patched', 'false');
+    ghOutput('reason', 'malformed-tool-input');
+    return;
+  }
+
+  const { newSelector, confidence, rationale } = input as ProposeSelectorInput;
+  console.log(`[auto-heal heal] proposal: confidence=${confidence}, selector=${newSelector}`);
+  console.log(`[auto-heal heal] rationale: ${rationale}`);
+
+  if (confidence < CONFIDENCE_THRESHOLD) {
+    console.log(`[auto-heal heal] confidence ${confidence} below threshold ${CONFIDENCE_THRESHOLD} — bailing`);
+    ghOutput('patched', 'false');
+    ghOutput('reason', 'low-confidence');
+    ghOutput('confidence', String(confidence));
+    return;
+  }
+  if (isBrittleSelector(newSelector)) {
+    console.log(`[auto-heal heal] selector "${newSelector}" looks brittle — bailing`);
+    ghOutput('patched', 'false');
+    ghOutput('reason', 'brittle-selector');
+    return;
+  }
+  if (newSelector === match.currentSelector) {
+    console.log(`[auto-heal heal] proposed selector identical to current — no-op`);
+    ghOutput('patched', 'false');
+    ghOutput('reason', 'identical-selector');
+    return;
+  }
+
+  // Apply the patch.
+  const patched = patchSelector(anchorsSource, anchorId, newSelector);
+  fs.writeFileSync(ANCHORS_PATH, patched);
+  console.log(`[auto-heal heal] patched ui-anchors.ts: ${match.currentSelector} -> ${newSelector}`);
+
+  // Re-probe locally.
+  console.log(`[auto-heal heal] re-running probe...`);
+  const probe = spawnSync('npm', ['run', '-s', 'probe:health'], {
+    encoding: 'utf8',
+    env: process.env,
+    stdio: 'inherit'
+  });
+  console.log(`[auto-heal heal] probe exit code: ${probe.status}`);
+
+  // Positive-confirmation invariant: we only emit patched=true when the
+  // re-probe contains the patched anchor AND every entry for it is `ok`.
+  // The naive `.some(status === 'fail')` check is false-positive on three
+  // shapes the re-probe can produce: (1) cdp-unreachable artifact has no
+  // `health` field; (2) probe wrote no `health.results`; (3) anchor was
+  // filtered out by phase mismatch and never actually probed. Each of
+  // those means "we don't know if the patch worked" — so revert, don't
+  // claim victory.
+  const reArtifact = latestArtifact();
+  if (!reArtifact) {
+    console.log(`[auto-heal heal] re-probe produced no artifact — reverting`);
+    revertAnchors();
+    ghOutput('patched', 'false');
+    ghOutput('reason', 're-probe-no-artifact');
+    return;
+  }
+  if (reArtifact.data.reason === 'cdp-unreachable') {
+    console.log(`[auto-heal heal] re-probe hit cdp-unreachable — cannot verify, reverting`);
+    revertAnchors();
+    ghOutput('patched', 'false');
+    ghOutput('reason', 're-probe-cdp-unreachable');
+    return;
+  }
+  const reResults = reArtifact.data.health?.results;
+  if (!Array.isArray(reResults) || reResults.length === 0) {
+    console.log(`[auto-heal heal] re-probe artifact has no health.results — reverting`);
+    revertAnchors();
+    ghOutput('patched', 'false');
+    ghOutput('reason', 're-probe-no-results');
+    return;
+  }
+  const entriesForAnchor = reResults.filter((r) => r.id === anchorId);
+  if (entriesForAnchor.length === 0) {
+    console.log(`[auto-heal heal] re-probe did not probe ${anchorId} (phase mismatch?) — reverting`);
+    revertAnchors();
+    ghOutput('patched', 'false');
+    ghOutput('reason', 're-probe-anchor-missing');
+    return;
+  }
+  const nonOk = entriesForAnchor.filter((r) => r.status !== 'ok');
+  if (nonOk.length > 0) {
+    console.log(
+      `[auto-heal heal] re-probe shows ${anchorId} still failing in ${nonOk.length}/${entriesForAnchor.length} phase(s) — reverting`
+    );
+    revertAnchors();
+    ghOutput('patched', 'false');
+    ghOutput('reason', 're-probe-still-failing');
+    return;
+  }
+
+  console.log(
+    `[auto-heal heal] re-probe green for ${anchorId} in ${entriesForAnchor.length} phase(s) — emitting step outputs`
+  );
+  const driftPr = findDriftPrNumber(date);
+  ghOutput('patched', 'true');
+  ghOutput('anchor-id', anchorId);
+  ghOutput('old-selector', match.currentSelector);
+  ghOutput('new-selector', newSelector);
+  ghOutput('confidence', String(confidence));
+  ghOutput('rationale', rationale);
+  ghOutput('drift-pr-number', driftPr != null ? String(driftPr) : '');
+  ghOutput('date', date);
+}
+
+function revertAnchors(): void {
+  try {
+    execSync(`git checkout -- ${path.relative(REPO_ROOT, ANCHORS_PATH)}`, {
+      cwd: REPO_ROOT,
+      stdio: 'inherit'
+    });
+  } catch (e) {
+    console.log(`[auto-heal heal] revert failed: ${(e as Error).message}`);
+  }
+}
+
+function anchorSourceBlock(source: string, id: string): string {
+  // Best-effort: scan line-by-line for `id: '<id>'` and return the surrounding
+  // 5 lines before / 25 after. Cheaper than re-walking the AST for a slice.
+  const lines = source.split('\n');
+  const needle = new RegExp(`id:\\s*['"\`]${id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"\`]`);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line !== undefined && needle.test(line)) {
+      const start = Math.max(0, i - 3);
+      const end = Math.min(lines.length, i + 25);
+      return lines.slice(start, end).join('\n');
+    }
+  }
+  return '(anchor block not located in source)';
+}
+
+// ---- entry ----
+
+async function main(): Promise<void> {
+  const cmd = process.argv[2];
+  if (cmd === 'triage') {
+    triage();
+  } else if (cmd === 'heal') {
+    const id = process.argv[3];
+    if (!id) {
+      console.error('Usage: auto-heal heal <anchor-id>');
+      process.exit(2);
+    }
+    await heal(id);
+  } else {
+    console.error('Usage: auto-heal triage | heal <anchor-id>');
+    process.exit(2);
+  }
+}
+
+main().catch((e: Error) => {
+  console.error(`[auto-heal] threw: ${e.message}`);
+  // Auto-heal is best-effort. Surface the error but exit 0 so the workflow
+  // doesn't go red on a recoverable script bug — the drift PR is still the
+  // human-readable fallback.
+  process.exit(0);
+});

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -109,6 +109,64 @@ async function ensureCdp(): Promise<CdpStatus> {
   return { alive: false, attemptedRestart: true, detail: final.detail };
 }
 
+function updateStreak(outDir: string, results: ProbeResult[]): void {
+  const streakPath = path.join(outDir, 'streak.json');
+  let streak: Record<string, number> = {};
+  if (fs.existsSync(streakPath)) {
+    try {
+      const raw = fs.readFileSync(streakPath, 'utf8');
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        // Only keep numeric values; anything else is corrupt + gets dropped.
+        for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+          if (typeof v === 'number' && Number.isFinite(v) && v >= 0) streak[k] = v;
+        }
+      }
+    } catch (e) {
+      console.log(`[ci-health] streak.json unreadable (${(e as Error).message}); resetting`);
+      streak = {};
+    }
+  }
+
+  // Group results by id. `any`-anchors run in both phases — a fail in either
+  // phase wins; ok-in-all-probed-phases resets to 0. Skipped anchors do not
+  // influence the streak (they didn't really probe).
+  const verdict = new Map<string, 'fail' | 'ok'>();
+  for (const r of results) {
+    if (r.status === 'skip') continue;
+    const prev = verdict.get(r.id);
+    if (r.status === 'fail') {
+      verdict.set(r.id, 'fail'); // fail wins over ok
+    } else if (r.status === 'ok' && prev !== 'fail') {
+      verdict.set(r.id, 'ok');
+    }
+  }
+
+  for (const [id, v] of verdict) {
+    if (v === 'fail') {
+      streak[id] = (streak[id] ?? 0) + 1;
+    } else {
+      streak[id] = 0;
+    }
+  }
+
+  // Best-effort write: a transient I/O failure here would (un-caught)
+  // bubble to main().catch() and replace the canonical probe-fail exit code
+  // 2 with a generic-throw exit code 3, changing the workflow's
+  // steps.probe.outcome semantics. The streak file is auto-heal's input
+  // signal, not the probe's contract — log + proceed.
+  try {
+    fs.writeFileSync(streakPath, JSON.stringify(streak, null, 2) + '\n');
+  } catch (e) {
+    console.log(`[ci-health] streak.json write failed (${(e as Error).message}); continuing`);
+    return;
+  }
+  const flagged = Object.entries(streak).filter(([, n]) => n >= 2);
+  if (flagged.length > 0) {
+    console.log(`[ci-health] streak >= 2: ${flagged.map(([id, n]) => `${id}=${n}`).join(', ')}`);
+  }
+}
+
 async function adaptiveWait(browser: Browser, sel: string, label: string): Promise<void> {
   // Wraps agent-browser `wait <selector>` (driven by AGENT_BROWSER_DEFAULT_TIMEOUT
   // = BROWSER_TIMEOUT_MS). On timeout we log + proceed — downstream anchor
@@ -251,6 +309,12 @@ async function main(): Promise<void> {
   ensureDir(outDir);
   const outFile = path.join(outDir, `${todayUtc()}.json`);
   fs.writeFileSync(outFile, JSON.stringify(payload, null, 2));
+
+  // Streak tracker — input to the auto-heal workflow's N=2 gate. Dedups
+  // across phases (a pattern.* anchor probed in both home + session counts
+  // as one fail-day if either phase failed, one ok-day only if both passed).
+  // Anchors not probed this run keep their existing streak value untouched.
+  updateStreak(outDir, results);
 
   // One-line summary for the workflow log.
   const summary = `[ci-health] ${payload.ok ? 'OK' : 'FAIL'} — health ${counts.ok} ok / ${counts.fail} fail / ${counts.skip} skip · doctor exit ${doctor.exitCode} · v${payload.designerVersion}`;


### PR DESCRIPTION
## Summary

Implements **#17**. When daily-health probe fails, a new `auto-heal` workflow fires on `workflow_run` completion, downloads the failing artifact, picks one anchor at streak ≥ 2, calls claude-opus-4-7 with the HTML snapshot + screenshot via tool-use, patches `ui-anchors.ts`, re-runs the probe locally to confirm green, and opens a PR for human review.

Task 2 of two. Builds on #18 (two-phase probe).

Closes #17

## Pipeline

```
daily-health.yml (conclusion=failure)
    │
    ▼
workflow_run → auto-heal.yml
    │
    ├── checkout @ workflow_run.head_sha
    ├── ensure labels (idempotent: auto-heal, wholesale-redesign-suspected)
    ├── download-artifact@v4 with run-id + github-token (cross-workflow)
    ├── npm ci
    ├── auto-heal triage (emits action=skip|heal)
    │     ├── skip if reason='cdp-unreachable' (infra fail)
    │     ├── skip if no streak >= 2 candidates
    │     ├── skip + comment+label if >= 5 anchors regressed (wholesale-redesign)
    │     ├── skip candidates that can't be AST-patched (V1 simple-hasSelector only)
    │     └── skip candidates within 7-day per-anchor cooldown
    ├── auto-heal heal <id> (if action=heal)
    │     ├── Anthropic SDK claude-opus-4-7 tool-use {newSelector, confidence, rationale}
    │     ├── bail if confidence < 0.7
    │     ├── bail if selector is brittle (:nth-child / pure structural)
    │     ├── bail if identical to current
    │     ├── patch ui-anchors.ts
    │     ├── run probe:health locally on the runner
    │     └── positive-confirmation: revert unless re-probe shows anchor=ok in
    │        every phase it appeared (cdp-unreachable / missing anchor / any-fail
    │        all trigger revert)
    └── peter-evans/create-pull-request@v6 with auto-heal label (if patched=true)
```

## Key Changes

### Features
- **`scripts/auto-heal.ts`**: orchestrator with `triage` and `heal` subcommands. Bails surface explicit `reason` outputs for log readability. All failure modes exit 0 — auto-heal is best-effort, the drift PR opened by daily-health remains as the human-readable diagnostic regardless.
- **`scripts/anchor-patcher.ts`**: TS-AST mutator using the already-installed `typescript` devDep. Three-function API (`findAnchor`, `canPatch`, `patchSelector`). V1 scope = the simple `hasSelector(b, '<sel>')` check shape (9 of the 19 anchors); complex `evalValue` walkers + `hasButtonMatching` are V2.
- **Streak tracker in `scripts/ci-health.ts`**: maintains `artifacts/health/streak.json` per run, deduped across phases (`pattern.*` anchors probed in both home + session count as one fail-day if either phase failed). Write wrapped in try/catch so a transient I/O failure doesn't replace exit code 2 with 3.
- **`.github/workflows/auto-heal.yml`**: `workflow_run` trigger on daily-health; cross-workflow artifact download (new pattern in this repo); peter-evans PR creation with `auto-heal` label only.
- **Dual auth**: workflow accepts either `ANTHROPIC_API_KEY` (x-api-key, per-token billing) OR `CLAUDE_CODE_OAUTH_TOKEN` (Bearer, Pro/Max subscription quota — installed by the Claude GitHub App in #20). No code path requires both.

### Dependency
- **`@anthropic-ai/sdk` ^0.96.0** added as runtime dep. Required for the heal step. `npm ci` on the runner picks it up automatically.

## Technical Context

- **Why claude-opus-4-7**: visual + reasoning capability justifies the cost. Estimated ~$0.10/heal call (6K tokens in including HTML + screenshot, ~200 tokens out via tool-use). The N=2 streak + 7-day cooldown keep frequency low. With OAuth, the cost is "uses your subscription quota" instead.
- **Positive-confirmation re-probe**: the naive `results.some(r => r.id === id && r.status === 'fail')` check is false-positive on three artifact shapes (cdp-unreachable, missing health field, anchor filtered by phase mismatch). The implementation requires the patched anchor to appear in re-probe results AND be `ok` in every phase it was probed.
- **AST patcher byte-precision**: round-trip verified locally — length delta exactly equals `len(newSel) - len(oldSel)`. The `quote` field captures the original literal's quote character and `escapeForQuote` handles backslashes / matching quote chars / `${` in backticks.
- **`workflow_run` trigger gotcha**: GitHub only dispatches `workflow_run` from the default-branch workflow definition. The full daily-health → auto-heal → PR chain therefore can't be exercised pre-merge — synthetic-drift validation is post-merge live-fire.

## ✅ Auth setup

`CLAUDE_CODE_OAUTH_TOKEN` was installed by #20 — auto-heal can use it directly via the SDK's `authToken` constructor option (Bearer header). No additional setup required for the OAuth path.

Optional fallback: if you'd rather use a metered API key, run `gh secret set ANTHROPIC_API_KEY --repo pro-vi/designer`. The code prefers `apiKey` when both are set.

**Caveat to verify on first live-fire**: the SDK plumbing supports OAuth via `authToken`, but I haven't independently confirmed that Anthropic's `/v1/messages` endpoint accepts Pro/Max OAuth tokens for direct SDK calls (vs. only via the Claude Code Action wrapper). If the first heal call returns 401, set `ANTHROPIC_API_KEY` as a fallback and re-run — both code paths are wired.

## Acceptance

- [x] **Typecheck + build** — `tsc --noEmit` green; CI (`ci.yml`) runs same on push.
- [x] **AST patcher round-trip** — `scripts/anchor-patcher.ts` validated against the real `ui-anchors.ts` source: 10/10 cases pass (4 simple anchors patchable, 5 complex anchors correctly rejected, 1 unknown-id rejected). Length delta on patch == `len(newSel) - len(oldSel)`.
- [x] **Triage logic, four branches** — verified locally with synthetic artifacts:
  - `action=heal` when one anchor at streak ≥ 2 is AST-patchable + not in cooldown ✓
  - `action=skip, reason=below-threshold` when no anchors above threshold ✓
  - `action=skip, reason=cdp-unreachable` when artifact reason is cdp-unreachable ✓
  - `action=skip, reason=wholesale-redesign` when ≥ 5 anchors regressed ✓
- [x] **Invariance gate** — fail-wins streak dedup verified across all four `(home, session)` cells; positive-confirmation re-probe enforced (cdp-unreachable / missing health / anchor missing all trigger revert).
- [x] **Dual-auth wiring** — `scripts/auto-heal.ts:339-353` accepts either credential; workflow plumbs both secrets through. Typecheck green.
- [x] **No automerge surface** — `auto-heal` PRs carry only the `auto-heal` label; `.github/workflows/dependabot-automerge.yml` only listens on `ci.yml`, not `daily-health.yml`. Cross-checked.
- [x] **End-to-end synthetic-drift dry-run** — `workflow_run` only fires from default-branch workflow definitions. After merge:
  1. Branch `validate/auto-heal-dryrun`; corrupt one selector (`create-project-button` → `create-project-buttonX`).
  2. Pre-seed `artifacts/health/streak.json` on the runner so we skip the 2-day wait.
  3. `gh workflow run daily-health.yml --ref validate/auto-heal-dryrun`.
  4. Confirm auto-heal opens a PR with the original selector proposed back.
  5. Capture the PR URL + screenshots; document in an issue comment or follow-up PR.

## Plan reference

- Plan: `~/.claude/plans/tmp-agent-brief-health-autoheal-md-iridescent-mccarthy.md` (U4–U9)
- Origin brief: `/tmp/agent-brief-health-autoheal.md`
- Issue: #17

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)