### PR TITLE
fix(setup): verify signed-in via DOM marker, not URL substring

### DIFF
--- a/setup.ts
+++ b/setup.ts
@@ -53,19 +53,32 @@ function chromeRunning(): boolean {
   return r.status === 0 && (r.stdout?.toString().trim().length ?? 0) > 0;
 }
 
-function chromeDebugProfile(port: string): string | null {
-  // Best-effort: read the --user-data-dir of the Chrome bound to this CDP
-  // port. Returns null when it can't be determined (non-digit port, no
-  // match, ps unavailable) — callers treat null as "unknown, proceed".
-  if (!/^\d+$/.test(port)) return null;
+type ProfileStatus = 'match' | 'mismatch' | 'unknown';
+
+function cdpChromeProfileStatus(port: string): ProfileStatus {
+  // Does the Chrome bound to this CDP port use OUR profile (PROFILE)?
+  //
+  // We deliberately do NOT try to parse an arbitrary --user-data-dir value
+  // out of `ps`'s output: ps renders the command line flat and unquoted, so
+  // a `/(\S+)/` capture truncates any path containing a space (e.g. a macOS
+  // home dir like `/Users/First Last/...`) and yields a false mismatch.
+  // Instead, since PROFILE is known, test for that exact path as a complete
+  // token. Returns 'unknown' when there's no Chrome / no --user-data-dir /
+  // ps failed; callers treat 'unknown' like 'match' (adopt-ok) because
+  // step4's DOM-marker check is the backstop.
+  if (!/^\d+$/.test(port)) return 'unknown';
   const r = spawnSync(
     'sh',
     ['-c', `ps -Axww -o command | grep -- '--remote-debugging-port=${port}' | grep -v grep`],
     { stdio: 'pipe' }
   );
-  if (r.status !== 0) return null;
-  const m = (r.stdout?.toString() ?? '').match(/--user-data-dir=(\S+)/);
-  return m?.[1] ?? null;
+  if (r.status !== 0) return 'unknown';
+  const out = r.stdout?.toString() ?? '';
+  if (!out.includes('--user-data-dir=')) return 'unknown';
+  // Literal match of PROFILE with a trailing boundary (space = next flag/URL,
+  // or end of line). Escaping handles regex metacharacters in the path.
+  const escaped = PROFILE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`--user-data-dir=${escaped}(?= |$)`, 'm').test(out) ? 'match' : 'mismatch';
 }
 
 async function pollUntil(
@@ -156,9 +169,9 @@ async function step3Chrome(port: string): Promise<boolean> {
     // CDP being reachable doesn't prove it's OUR debug Chrome. Adopt only
     // when the profile matches (or can't be determined — step4's DOM-marker
     // check backstops that case).
-    const runningProfile = chromeDebugProfile(port);
-    if (!runningProfile || runningProfile === PROFILE) {
-      log('chrome', 'ok', `CDP already up on :${port}${runningProfile ? ' (profile matches)' : ''}`);
+    const profileStatus = cdpChromeProfileStatus(port);
+    if (profileStatus !== 'mismatch') {
+      log('chrome', 'ok', `CDP already up on :${port}${profileStatus === 'match' ? ' (profile matches)' : ''}`);
       return true;
     }
     // A debug Chrome on this port under a different --user-data-dir can't be
@@ -170,9 +183,7 @@ async function step3Chrome(port: string): Promise<boolean> {
     log(
       'chrome',
       'wait',
-      `A debug Chrome is on :${port} with a different profile:\n` +
-        `   running:  ${runningProfile}\n` +
-        `   expected: ${PROFILE}\n` +
+      `A debug Chrome is on :${port} with a different --user-data-dir (expected ${PROFILE}).\n` +
         `   Quit it — I'll launch one with the right profile once it's gone. (Or set DESIGNER_CDP to a free port.)`
     );
     const freed = await pollUntil('chrome', async () => !(await isCdpUp(port)), {

--- a/setup.ts
+++ b/setup.ts
@@ -4,6 +4,7 @@ import os from 'node:os';
 import { spawn, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { REPO_ROOT } from './repo-root.ts';
+import { createBrowser, type Browser } from './browser.ts';
 
 const SKILL_SRC = path.join(REPO_ROOT, 'skills', 'designer-loop', 'SKILL.md');
 const SKILL_DEST_DIR = path.join(os.homedir(), '.claude', 'skills', 'designer-loop');
@@ -32,25 +33,39 @@ async function isCdpUp(port: string): Promise<boolean> {
   }
 }
 
-async function getDesignTab(port: string): Promise<{ url: string; title: string } | null> {
-  try {
-    const res = await fetch(`http://127.0.0.1:${port}/json/list`, { signal: AbortSignal.timeout(2000) });
-    if (!res.ok) return null;
-    const tabs = (await res.json()) as Array<{ url?: string; title?: string }>;
-    for (const t of tabs) {
-      if (t.url && /claude\.ai\/design/.test(t.url) && !/login/i.test(t.url)) {
-        return { url: t.url, title: t.title || '' };
-      }
-    }
-    return null;
-  } catch {
-    return null;
-  }
+async function verifySignedIn(browser: Browser): Promise<boolean> {
+  // A signed-in claude.ai/design session renders one of these app-shell
+  // anchors — `project-creator` on the home surface, `chat-composer-input`
+  // inside a project. A logged-out visit to claude.ai/design renders a
+  // login wall with neither.
+  //
+  // This replaces the old URL-only check (URL matches /design && !/login/).
+  // That check passed the login wall served AT the /design URL — the URL
+  // stays `/design` when logged out, no `/login` substring — which is the
+  // #16 false positive. The DOM is the only reliable signal.
+  const js =
+    '!!(document.querySelector(\'[data-testid="project-creator"]\') || document.querySelector(\'[data-testid="chat-composer-input"]\'))';
+  return browser.evalValue<boolean>(js).catch(() => false);
 }
 
 function chromeRunning(): boolean {
   const r = spawnSync('pgrep', ['-f', 'Google Chrome.app/Contents/MacOS/Google Chrome'], { stdio: 'pipe' });
   return r.status === 0 && (r.stdout?.toString().trim().length ?? 0) > 0;
+}
+
+function chromeDebugProfile(port: string): string | null {
+  // Best-effort: read the --user-data-dir of the Chrome bound to this CDP
+  // port. Returns null when it can't be determined (non-digit port, no
+  // match, ps unavailable) — callers treat null as "unknown, proceed".
+  if (!/^\d+$/.test(port)) return null;
+  const r = spawnSync(
+    'sh',
+    ['-c', `ps -Axww -o command | grep -- '--remote-debugging-port=${port}' | grep -v grep`],
+    { stdio: 'pipe' }
+  );
+  if (r.status !== 0) return null;
+  const m = (r.stdout?.toString() ?? '').match(/--user-data-dir=(\S+)/);
+  return m?.[1] ?? null;
 }
 
 async function pollUntil(
@@ -138,7 +153,25 @@ function step2AgentBrowser(): boolean {
 
 async function step3Chrome(port: string): Promise<boolean> {
   if (await isCdpUp(port)) {
-    log('chrome', 'ok', `CDP already up on :${port}`);
+    // CDP being reachable doesn't prove it's OUR debug Chrome. If a debug
+    // Chrome is on this port under a different --user-data-dir, adopting it
+    // means the sign-in step lands in the wrong profile — and future runs
+    // with the right profile stay logged out. Fail loud on a profile
+    // mismatch; proceed when it matches or can't be determined (step4's
+    // DOM-marker check is the backstop for the can't-determine case).
+    const runningProfile = chromeDebugProfile(port);
+    if (runningProfile && runningProfile !== PROFILE) {
+      log(
+        'chrome',
+        'fail',
+        `A debug Chrome is on :${port} but using a different profile:\n` +
+          `   running:  ${runningProfile}\n` +
+          `   expected: ${PROFILE}\n` +
+          `   Quit that Chrome and re-run setup, or set DESIGNER_CDP to a free port.`
+      );
+      return false;
+    }
+    log('chrome', 'ok', `CDP already up on :${port}${runningProfile ? ' (profile matches)' : ''}`);
     return true;
   }
   if (chromeRunning()) {
@@ -177,23 +210,29 @@ async function step3Chrome(port: string): Promise<boolean> {
 }
 
 async function step4SignIn(port: string): Promise<boolean> {
-  const tab = await getDesignTab(port);
-  if (tab) {
-    log('login', 'ok', `Signed in. Tab on ${tab.url.replace(/\?.*$/, '')}`);
-    return true;
-  }
-  log('login', 'wait', 'Sign in to Claude in the DEBUG Chrome window I just opened (it is a separate window with no extensions/bookmarks — NOT your normal Chrome; the two have separate cookie jars). Then navigate to claude.ai/design. I am polling.');
-  const ok = await pollUntil('login', async () => (await getDesignTab(port)) !== null, {
+  const browser = createBrowser({ session: 'designer-setup', cdp: port });
+  // Normalize: the adopted Chrome's tab could be anywhere (about:blank, a
+  // stale page, a project). Land it on the design home so the poll has a
+  // consistent surface, then let the SPA paint before the first check.
+  await browser.open('https://claude.ai/design').catch(() => undefined);
+  await sleep(2500);
+
+  // pollUntil checks the predicate before emitting any reminder — so an
+  // already-signed-in session returns true on the first iteration and the
+  // user never sees the sign-in prompt.
+  const ok = await pollUntil('login', () => verifySignedIn(browser), {
     intervalMs: 2000,
     timeoutMs: 10 * 60_000,
-    reminder: 'Still waiting for a tab on claude.ai/design in the debug window (signing into your normal Chrome will not help — different profile).',
+    reminder:
+      'Sign in to Claude in the DEBUG Chrome window I just opened (a separate window with no extensions/bookmarks — NOT your normal Chrome; the two have separate cookie jars). Then return to claude.ai/design. I am polling.',
     hint60s: "If Chrome shows a Google 'new device' or 2FA prompt, complete that first — setup is waiting on you."
   });
   if (!ok) {
-    log('login', 'fail', 'Timed out waiting for sign-in. Re-run setup when ready.');
+    log('login', 'fail', 'Timed out waiting for a signed-in claude.ai/design session. Re-run setup when ready.');
     return false;
   }
-  log('login', 'ok', 'Signed in.');
+  const url = (await browser.url().catch(() => '')) || 'claude.ai/design';
+  log('login', 'ok', `Signed in. Tab on ${url.replace(/\?.*$/, '')}`);
   return true;
 }
 

--- a/setup.ts
+++ b/setup.ts
@@ -153,26 +153,38 @@ function step2AgentBrowser(): boolean {
 
 async function step3Chrome(port: string): Promise<boolean> {
   if (await isCdpUp(port)) {
-    // CDP being reachable doesn't prove it's OUR debug Chrome. If a debug
-    // Chrome is on this port under a different --user-data-dir, adopting it
-    // means the sign-in step lands in the wrong profile — and future runs
-    // with the right profile stay logged out. Fail loud on a profile
-    // mismatch; proceed when it matches or can't be determined (step4's
-    // DOM-marker check is the backstop for the can't-determine case).
+    // CDP being reachable doesn't prove it's OUR debug Chrome. Adopt only
+    // when the profile matches (or can't be determined — step4's DOM-marker
+    // check backstops that case).
     const runningProfile = chromeDebugProfile(port);
-    if (runningProfile && runningProfile !== PROFILE) {
-      log(
-        'chrome',
-        'fail',
-        `A debug Chrome is on :${port} but using a different profile:\n` +
-          `   running:  ${runningProfile}\n` +
-          `   expected: ${PROFILE}\n` +
-          `   Quit that Chrome and re-run setup, or set DESIGNER_CDP to a free port.`
-      );
+    if (!runningProfile || runningProfile === PROFILE) {
+      log('chrome', 'ok', `CDP already up on :${port}${runningProfile ? ' (profile matches)' : ''}`);
+      return true;
+    }
+    // A debug Chrome on this port under a different --user-data-dir can't be
+    // adopted — sign-in would land in the wrong profile. Don't bail outright:
+    // mirror the non-debug-Chrome branch below — ask the user to quit it,
+    // poll, then fall through and launch one with the right profile. Same
+    // safety (we still never adopt the wrong profile) without forcing a
+    // manual re-run of setup.
+    log(
+      'chrome',
+      'wait',
+      `A debug Chrome is on :${port} with a different profile:\n` +
+        `   running:  ${runningProfile}\n` +
+        `   expected: ${PROFILE}\n` +
+        `   Quit it — I'll launch one with the right profile once it's gone. (Or set DESIGNER_CDP to a free port.)`
+    );
+    const freed = await pollUntil('chrome', async () => !(await isCdpUp(port)), {
+      intervalMs: 1000,
+      timeoutMs: 5 * 60_000,
+      reminder: `Still waiting for the wrong-profile debug Chrome on :${port} to quit.`
+    });
+    if (!freed) {
+      log('chrome', 'fail', `Timed out waiting for the debug Chrome on :${port} to quit. Quit it manually, then re-run setup.`);
       return false;
     }
-    log('chrome', 'ok', `CDP already up on :${port}${runningProfile ? ' (profile matches)' : ''}`);
-    return true;
+    // fall through to the launch path
   }
   if (chromeRunning()) {
     log('chrome', 'wait', 'A non-debug Chrome is running. Quit it (Cmd+Q on the Chrome menu, then close Activity Monitor entries if any). I am polling.');


### PR DESCRIPTION
## Summary

Closes **#16** — `designer setup` false-positive sign-in detection.

After reading `setup.ts`, the issue's filed hypotheses were close but **Bug B was subtler than described**.

### Bug B — the false positive (`step4SignIn` / `getDesignTab`)
The signed-in check was **URL-only**: `/claude\.ai\/design/.test(url) && !/login/i.test(url)`. The real failure isn't "the login redirect touches /design" — it's that **`claude.ai/design` itself renders a login wall when logged out**. The URL stays `/design`, there's no `/login` substring, so a logged-out session passed as "signed in." `setup` exited green leaving Chrome on a login page; `designer doctor` / `designer health` then failed confusingly downstream.

**Fix:** `verifySignedIn()` probes the **DOM** via agent-browser (already verified present in `step2`) for an app-shell anchor that only renders when authenticated — `[data-testid="project-creator"]` (home surface) or `[data-testid="chat-composer-input"]` (inside a project). The new failure mode is a false *negative* if those testids drift — the **safe** direction (user re-confirms sign-in vs. silently-broken setup), and those exact anchors are already monitored by the daily-health probe.

### Bug A — blind Chrome adoption (`step3Chrome`)
`step3` treated *any* CDP-reachable Chrome on the port as ours. If a debug Chrome is bound there under a different `--user-data-dir`, adopting it means sign-in lands in the wrong profile (and future runs with the right profile stay logged out).

**Fix:** `chromeDebugProfile()` reads the running Chrome's `--user-data-dir` via `ps`. On a profile **match** (or when it can't be determined — step4's DOM check backstops that), `step3` adopts it. On a **mismatch**, `step3` does NOT adopt it — and rather than bailing outright, it **polls for that Chrome to quit then falls through to launch one with the correct profile** — mirroring the sibling `chromeRunning()` branch that handles a non-debug Chrome blocking the port. Same safety (the wrong-profile Chrome is never adopted), without forcing a manual re-run of `setup`.

### Also
- `step4` navigates the tab to `claude.ai/design` once before polling, so the adopt path (tab could be on `about:blank` / a stale page / a project) has a consistent surface to check.
- Removed the now-dead URL-only `getDesignTab` helper.

## Commits

1. `verify signed-in via DOM marker, not URL substring` — Bug B + initial Bug A guard
2. `poll-and-recover on wrong-profile Chrome, don't bail` — Bug A consistency: poll instead of fail-loud

## Acceptance

- [x] **Typecheck** — `tsc --noEmit` green; CI green.
- [x] **`chromeDebugProfile()`** — tested against real throwaway Chromes (`--headless`, temp `--user-data-dir`, ports 9333 and 9222): extracts the exact `--user-data-dir` from `ps` output; returns `null` for an absent port and a non-digit port.
- [x] **`verifySignedIn()` — positive case** — tested on the self-hosted runner against a live signed-in `claude.ai/design` session: `[data-testid="project-creator"]` present, combined OR eval returns `true`, `evalValue` plumbing confirmed end-to-end. (Evidence in PR comment.)
- [x] **Bug B path — interactive E2E** — ran `npm run setup` with a non-debug Chrome running → `step3` detected it, prompted to quit, recovered → `step4` `verifySignedIn` confirmed the signed-in session and completed. (Happy path; see gap below.)
- [x] **Bug A path — interactive E2E** — ran `npm run setup` with a headed debug Chrome on `:9222` under a temp `--user-data-dir` → `step3` polled with the profile-mismatch message → Cmd+Q'd the test Chrome → `setup` recovered in place and launched its own debug Chrome with `~/.chrome-designer-profile`. No re-run needed.
- [ ] **Bug B negative case** — not explicitly exercised: confirming `verifySignedIn` returns `false` against an *actual* logged-out `claude.ai/design` login wall needs a deliberately logged-out debug Chrome. The interactive run hit the signed-in happy path. The false-path is sound by construction (`!!(null || null)` → `false`) and the runner test confirms a signed-in page *has* the markers — but the login wall wasn't *seen* returning false.

## Key Changes

- **`setup.ts`** — `verifySignedIn()` (DOM-marker probe, replaces URL check), `chromeDebugProfile()` (profile-match guard), `step3Chrome` profile-mismatch poll-and-recover, `step4SignIn` rewritten to navigate-then-poll. `getDesignTab` deleted.

## Note

Out of scope (intentionally): `scripts/ci-health.ts`'s `ensureCdp()` has the same *class* of "CDP up but not logged in" gap (noted in #16's Impact section). It's on an already-set-up self-hosted runner, not the user-facing path — a separate, lower-priority follow-up if it ever bites.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)