### PR TITLE
fix(anchors): replace chatTurnPrefix text-prefix check with data-index API

### DIFF
--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -147,18 +147,20 @@ export const UI_ANCHORS: AnchorDef[] = [
     }
   },
   {
+    // Legacy id (kept to avoid resetting the persisted streak counter). The
+    // original check asserted a 'You\n' / 'Claude\n' text prefix on each
+    // chat turn, but Claude's May 2026 chat redesign removed the in-text
+    // speaker label — turns are now visually distinguished by wrapper
+    // styling, not by a text prefix. Replace with an assertion against
+    // Claude's intentional `data-index="N"` API on each turn row: matching
+    // [data-index="1"] confirms the conversation has >=2 turns AND that the
+    // indexing API still exists. Shape is now simple-hasSelector so future
+    // drift of this anchor is auto-heal-patchable.
     id: 'session.chatTurnPrefix',
     category: 'pattern',
-    description: "chat turns prefixed with 'You\\n' / 'Claude\\n'",
+    description: 'chat-messages renders >=2 turn rows (data-index API)',
     requires: 'session',
-    check: async (b) => {
-      const sample = await b.evalValue<string>(
-        `(() => { const c = document.querySelector('[data-testid="chat-messages"]'); const inner = c && c.children[0]; if (!inner) return ''; return Array.from(inner.children).slice(0, 3).map(d => (d.innerText||'').slice(0, 40)).join('|'); })()`
-      ).catch(() => '');
-      if (!sample) return { ok: false, detail: 'no chat turns' };
-      const ok = /(^|\|)(You|Claude)(\\n|\n|$)/.test(sample) || /You\n|Claude\n/.test(sample);
-      return { ok, detail: ok ? undefined : `first turns: ${sample.slice(0, 120)}` };
-    }
+    check: async (b) => ({ ok: await hasSelector(b, '[data-testid="chat-messages"] [data-index="1"]') })
   },
 
   // --- share dialog (formerly the Export dropdown; moved under Share ~2026-04-19) ---


### PR DESCRIPTION
## Summary

Yesterday's daily-health cron caught a real drift: `session.chatTurnPrefix` failed (streak = 1). Claude's chat redesign removed the in-text `You\n` / `Claude\n` speaker label from turns — they're now visually distinguished by wrapper styling, and the speaker label isn't in the `innerText` flow at all.

## What changed

DOM inspection on the live runner showed each chat turn row carries `data-index="N"` — Claude's intentional virtualization API. Replaced the old `evalValue` scraper-on-prefix-text with a simple `hasSelector(b, '[data-testid="chat-messages"] [data-index="1"]')`:

- Asserts the conversation has **≥2 turns** (a fresh empty chat would fail; a multi-turn canary passes)
- Asserts the `data-index` semantic API still exists (drift detection on a stable signal)
- **New shape is `canPatch === true`** in the V1 anchor-patcher — future drifts of this anchor are auto-heal-patchable

Anchor id (`session.chatTurnPrefix`) kept as-is to avoid resetting the persisted streak counter — it's a stable label. Description updated to reflect the new assertion.

## Verification

1. **Typecheck** — `tsc --noEmit` green; CI runs typecheck + Docker smoke.
2. **Live selector eval** — SSH'd to the self-hosted runner, evaluated `!!document.querySelector('[data-testid="chat-messages"] [data-index="1"]')` against the live signed-in canary chat session → `true`. Also confirmed 7 elements with `data-index` inside `chat-messages` (lots of turn rows visible).
3. **`canPatch` round-trip** — ran `findAnchor` / `canPatch` against the new `ui-anchors.ts` source: returns `true`, extracts selector `[data-testid="chat-messages"] [data-index="1"]`. The anchor is now auto-heal-patchable.
4. **Live-fire E2E** — triggered `workflow_dispatch` of `daily-health.yml` on this branch (see linked run). Expecting `counts.ok = 19, fail = 0`.

## Background

This is the first real anchor drift caught by the merged auto-heal pipeline (#18/#19/#21/#22). Validates that the chain works end-to-end: probe detects drift → drift PR opens (#23) → workflow_run triggers auto-heal → triage correctly skips below-threshold → exit 0, no false-positive PR.

The old check used a complex `evalValue` regex scraper, so it wasn't V1-patchable by auto-heal even if it had hit streak ≥ 2 — auto-heal would have skipped with `not-patchable` (reason: V1 complex-check limit). The new shape closes that gap.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)