### PR TITLE
fix(workflows): add /opt/homebrew/bin to PATH on self-hosted runner

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -58,6 +58,16 @@ jobs:
           # rebase as needed when opening the PR.
           ref: ${{ github.event.workflow_run.head_sha }}
 
+      - name: Setup gh PATH
+        # The self-hosted Mac mini runner has gh at /opt/homebrew/bin/gh
+        # (Homebrew), but the workflow's non-interactive bash doesn't inherit
+        # that PATH from ~/.zshrc — it only gets nvm's node bin. Prepend
+        # Homebrew's bin to $GITHUB_PATH so every subsequent step (including
+        # the npm-spawned auto-heal script's gh() helper) can find gh.
+        # Without this, `Ensure labels exist` + the script's cooldown /
+        # wholesale-redesign / findDriftPrNumber checks silently no-op.
+        run: echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+
       - name: Ensure labels exist (idempotent)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -42,6 +42,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup gh PATH
+        # The self-hosted Mac mini runner has gh at /opt/homebrew/bin/gh
+        # (Homebrew), but the workflow's non-interactive bash doesn't inherit
+        # that PATH from ~/.zshrc — it only gets nvm's node bin. Prepend
+        # Homebrew's bin to $GITHUB_PATH so every subsequent step (including
+        # npm-spawned subprocesses that inherit process.env, e.g.
+        # scripts/auto-heal.ts's gh() helper) can find gh. Without this, the
+        # `Close stale drift PRs on green` step + auto-heal's `Ensure labels
+        # exist` step + the script's cooldown / wholesale-redesign checks
+        # silently no-op (`|| true` hides the failure; step exits "success").
+        run: echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+
       # The runner already has a node, but pinning it here keeps the Mac mini's
       # global node version free to drift without breaking this job.
       - name: Setup node


### PR DESCRIPTION
## Summary

Fixes a latent bug discovered while debriefing the May 15 + May 16 cron cycles. PR #23 (May 14's drift) was still open despite two green probes — the workflow's "Close stale drift PRs on green" step has been silently no-op'ing since shipped:

```
sh: line 1: gh: command not found
```

`gh` is at `/opt/homebrew/bin/gh` on the self-hosted Mac mini (Homebrew). Login shells find it via `~/.zshrc`, but GitHub Actions' non-interactive bash for `run:` steps only inherits nvm's node bin. `|| true` chains hid every failure; step-level `conclusion: success` was misleading.

## Impact

**Active**: `daily-health.yml`'s `Close stale drift PRs on green` has never actually closed a PR. (PR #23 manually closed during investigation.)

**Latent** — would bite the first time auto-heal reaches the heal path on a real streak ≥ 2 simple-shape drift:
- `auto-heal.yml`'s `Ensure labels exist` — auto-heal / wholesale-redesign-suspected labels wouldn't get created
- `scripts/auto-heal.ts`'s `gh()` helper — `isWithinCooldown` silently returns false (could open duplicate PRs); `findDriftPrNumber` silently returns null (wholesale-redesign comment never posts)

## Fix

One `Setup gh PATH` step at the top of each self-hosted workflow:

```yaml
- name: Setup gh PATH
  run: echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
```

Once set, the PATH propagates to **all subsequent steps in the workflow run** — including npm-spawned subprocesses, so `auto-heal.ts`'s `gh()` helper (which uses `spawnSync('gh', args, { env: process.env })`) inherits the fix automatically. **No script changes needed.**

## Files

- `.github/workflows/daily-health.yml` — new step after Checkout, before `Close stale drift PRs on green`
- `.github/workflows/auto-heal.yml` — new step after Checkout, before `Ensure labels exist` + `Triage` / `Heal`

The five GitHub-hosted workflows (`ci.yml`, `dependabot-automerge.yml`, `claude.yml`, `release-please.yml`, `release-publish.yml`, `lockfile-refresh.yml`) are unaffected — Ubuntu runners include gh by default.

## Verification

- [x] YAML parse (`ruby -ryaml`)
- [x] `npm run check` typecheck (no script changes, insurance)
- [ ] **Pre-merge live-fire** — `gh workflow run daily-health.yml --ref fix/gh-path --field open-pr-on-fail=false`, then confirm the runtime stdout of `Close stale drift PRs on green` no longer contains `gh: command not found`. Probe stays green (19/19).
- [ ] **Post-merge passive** — first scheduled cron after merge confirms close-stale works on any future drift; first real auto-heal trigger confirms label step + script's `gh()` work.

## Plan reference

- Plan: `~/.claude/plans/tmp-agent-brief-health-autoheal-md-iridescent-mccarthy.md` (Fast-follow #3 section)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)