### PR TITLE
Fix designer CLI version metadata

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -12,6 +12,7 @@ import { runSetup } from './setup.ts';
 import { startMcpServer } from './mcp-server.ts';
 import { REPO_ROOT } from './repo-root.ts';
 import { runHealth } from './ui-anchors.ts';
+import { PACKAGE_VERSION } from './package-meta.ts';
 
 const [, , cmd, ...rest] = process.argv;
 
@@ -48,6 +49,11 @@ const flags = parseFlags(rest);
 const key = (flags.key as string) || 'default';
 
 async function main(): Promise<void> {
+  if (cmd === '--version' || cmd === '-v' || cmd === 'version' || flags.version === true || flags.v === true) {
+    console.log(PACKAGE_VERSION);
+    return;
+  }
+
   // Honor --help / -h at the top: `designer <verb> --help` prints just that verb's
   // expanded docs. Done here rather than in each case so every verb gets it free.
   if (flags.help === true || flags.h === true) {

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -7,8 +7,9 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import { DesignerController } from './designer-controller.ts';
 import { sessionDir } from './artifact-store.ts';
+import { PACKAGE_VERSION } from './package-meta.ts';
 
-const server = new McpServer({ name: 'designer', version: '0.3.0' });
+const server = new McpServer({ name: 'designer', version: PACKAGE_VERSION });
 const controllers = new Map<string, DesignerController>();
 
 function getController(key: string | undefined): DesignerController {

--- a/package-meta.ts
+++ b/package-meta.ts
@@ -1,0 +1,23 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { REPO_ROOT } from './repo-root.ts';
+
+interface PackageMetadata {
+  name: string;
+  version: string;
+}
+
+function readPackageMetadata(): PackageMetadata {
+  const raw = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8')) as {
+    name?: unknown;
+    version?: unknown;
+  };
+
+  return {
+    name: typeof raw.name === 'string' ? raw.name : 'designer',
+    version: typeof raw.version === 'string' ? raw.version : '0.0.0'
+  };
+}
+
+export const PACKAGE_METADATA = readPackageMetadata();
+export const PACKAGE_VERSION = PACKAGE_METADATA.version;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cli": "tsx cli.ts",
     "setup": "tsx cli.ts setup",
     "doctor": "tsx cli.ts doctor",
+    "test": "npm run build && node --test tests/cli-metadata.test.mjs",
     "check": "tsc --noEmit",
     "build": "tsc -p tsconfig.build.json",
     "prepack": "npm run check && npm run build",

--- a/tests/cli-metadata.test.mjs
+++ b/tests/cli-metadata.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+
+async function runDesigner(args) {
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, ['dist/cli.js', ...args], { cwd: root });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    return {
+      code: error.code,
+      stdout: error.stdout ?? '',
+      stderr: error.stderr ?? ''
+    };
+  }
+}
+
+test('top-level version flags print the package version', async () => {
+  for (const args of [['--version'], ['-v'], ['version']]) {
+    const result = await runDesigner(args);
+    assert.equal(result.code, 0);
+    assert.equal(result.stdout.trim(), pkg.version);
+    assert.equal(result.stderr.trim(), '');
+  }
+});
+
+test('top-level help remains successful', async () => {
+  const result = await runDesigner(['--help']);
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /CLI \+ MCP/);
+  assert.equal(result.stderr.trim(), '');
+});


### PR DESCRIPTION
## Summary
- add package metadata loading from package.json
- make designer --version, -v, and version print the package version with exit 0
- use the same package version for MCP server metadata
- add a Node test for top-level CLI metadata flags

## Reproduction
`npm exec --yes --package=@pro-vi/designer@0.3.7 -- designer --version` currently prints the top-level help and exits 1.

## Validation
- `npm run check`
- `npm test`
- `node dist/cli.js --version`, `-v`, `version`, and `mcp serve --version`
- local `npm pack` tarball smoke with `npm exec --package=./pro-vi-designer-0.3.7.tgz -- designer --version`, `-v`, and `version`

`npm run smoke` was also attempted, but this local machine has no running Docker/Colima socket at `/Users/wowsofine/.colima/default/docker.sock`.