### PR TITLE
fix(drift): track 2026-06 claude.ai/design layout

### DIFF
--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -321,24 +321,48 @@ export class DesignerController {
   async _submitPrompt(prompt: string): Promise<void> {
     const { promptTextarea, sendButton } = this.selectors.composer;
     await this.browser.waitFor(promptTextarea);
-    // React-controlled textarea: bypass React's value ownership via the native
-    // HTMLTextAreaElement setter, then fire a bubbling input event. This is
-    // the canonical React-safe programmatic input pattern.
+    // The composer has shipped as both a React-controlled <textarea> and a
+    // ProseMirror contenteditable <div> — branch on what's actually there.
     await this.browser.evalValue<boolean>(
       `(() => {
-        const ta = document.querySelector(${JSON.stringify(promptTextarea)});
-        if (!ta) throw new Error('textarea not found');
-        const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
-        setter.call(ta, ${JSON.stringify(prompt)});
-        ta.dispatchEvent(new Event('input', { bubbles: true }));
-        ta.focus();
-        return true;
+        const el = document.querySelector(${JSON.stringify(promptTextarea)});
+        if (!el) throw new Error('composer input not found');
+        const text = ${JSON.stringify(prompt)};
+        if (el instanceof HTMLTextAreaElement) {
+          // Bypass React's value ownership via the native setter, then fire a
+          // bubbling input event.
+          const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+          setter.call(el, text);
+          el.dispatchEvent(new Event('input', { bubbles: true }));
+          el.focus();
+          return true;
+        }
+        if (el.isContentEditable) {
+          // Deliver the text as a synthetic paste so the editor's own paste
+          // pipeline updates its internal state; execCommand('insertText')
+          // flattens multi-line prompts into one paragraph.
+          el.focus();
+          const sel = window.getSelection();
+          const range = document.createRange();
+          range.selectNodeContents(el);
+          sel.removeAllRanges();
+          sel.addRange(range);
+          const dt = new DataTransfer();
+          dt.setData('text/plain', text);
+          const unhandled = el.dispatchEvent(new ClipboardEvent('paste', { clipboardData: dt, bubbles: true, cancelable: true }));
+          if (unhandled) {
+            // No editor intercepted the paste — plain contenteditable fallback.
+            document.execCommand('insertText', false, text);
+          }
+          return true;
+        }
+        throw new Error('composer input is neither textarea nor contenteditable: ' + el.tagName);
       })()`
     );
     for (let i = 0; i < 30; i++) {
       await new Promise((r) => setTimeout(r, 150));
       const disabled = await this.browser.evalValue<boolean>(
-        `(() => { const b = document.querySelector(${JSON.stringify(sendButton)}); return !b || b.disabled; })()`
+        `(() => { const b = document.querySelector(${JSON.stringify(sendButton)}); return !b || b.disabled || b.getAttribute('aria-disabled') === 'true'; })()`
       );
       if (!disabled) break;
     }
@@ -718,7 +742,11 @@ export class DesignerController {
     const opened = await this._clickButtonByText(/^Share$/).catch(() => null);
     if (!opened) await this._clickButtonByText(/^Export$/);
     await new Promise((r) => setTimeout(r, 400));
-    await this._clickButtonByText(/handoff to claude code/i);
+    // ~2026-06: Share opens a tabbed dialog; handoff lives under the
+    // "Send to…" tab as a "Claude Code" destination row. Older builds had a
+    // direct "Handoff to Claude Code" menu item — keep it as the fallback.
+    const viaSendTo = await this._clickClaudeCodeSendTo().catch(() => false);
+    if (!viaSendTo) await this._clickButtonByText(/handoff to claude code/i);
 
     let handoffUrl = '';
     for (let i = 0; i < 30; i++) {
@@ -787,6 +815,38 @@ export class DesignerController {
         const btn = Array.from(document.querySelectorAll('button')).find(b => re.test((b.textContent || '').trim()));
         if (!btn) throw new Error('button not found: ' + ${JSON.stringify(re.source)});
         btn.click();
+        return true;
+      })()`
+    );
+  }
+
+  // Navigate the tabbed Share dialog (2026-06 layout): "Send to…" tab →
+  // "Claude Code" destination row → its Send button. The row's Send button
+  // has no testid and its label text ("Claude Code", "Hand off the project
+  // to your terminal") lives in sibling elements, so match by walking up to
+  // the row container. Returns false if the tab or row isn't there, so the
+  // caller can fall back to the legacy direct menu item.
+  async _clickClaudeCodeSendTo(): Promise<boolean> {
+    const tabClicked = await this.browser.evalValue<boolean>(
+      `(() => {
+        const tab = Array.from(document.querySelectorAll('button[role="tab"]')).find(t => /send to/i.test(t.textContent || ''));
+        if (!tab) return false;
+        tab.click();
+        return true;
+      })()`
+    );
+    if (!tabClicked) return false;
+    await new Promise((r) => setTimeout(r, 400));
+    return this.browser.evalValue<boolean>(
+      `(() => {
+        const sends = Array.from(document.querySelectorAll('button')).filter(b => (b.textContent || '').trim() === 'Send');
+        const target = sends.find(b => {
+          let row = b;
+          for (let i = 0; i < 3 && row.parentElement; i++) row = row.parentElement;
+          return /claude code/i.test(row.textContent || '');
+        });
+        if (!target) return false;
+        target.click();
         return true;
       })()`
     );

--- a/selectors.json
+++ b/selectors.json
@@ -18,7 +18,7 @@
   },
   "composer": {
     "promptTextarea": "[data-testid=\"chat-composer-input\"]",
-    "sendButton": "[data-testid=\"chat-send-button\"]",
+    "sendButton": "[data-testid=\"chat-send-button\"], button[title^=\"Send (\"]",
     "stopButton": null,
     "attachButton": "button[aria-label=\"Attach file\"]",
     "modelButton": "[data-testid=\"model-selector-button\"]"

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -110,7 +110,9 @@ export const UI_ANCHORS: AnchorDef[] = [
     category: 'session',
     description: 'send button',
     requires: 'session',
-    check: async (b) => ({ ok: await hasSelector(b, '[data-testid="chat-send-button"]') })
+    // The 2026-06 build dropped data-testid="chat-send-button"; the button is
+    // now only identifiable by its title="Send (Enter)". Match either.
+    check: async (b) => ({ ok: await hasSelector(b, '[data-testid="chat-send-button"], button[title^="Send ("]') })
   },
   {
     id: 'session.htmlViewerIframe',
@@ -174,7 +176,7 @@ export const UI_ANCHORS: AnchorDef[] = [
   {
     id: 'share.handoffMenuItem',
     category: 'share',
-    description: 'Handoff-to-Claude-Code menu item (inside Share dropdown)',
+    description: 'Handoff-to-Claude-Code action (Share → Send to… tab → Claude Code row, or the legacy dropdown item)',
     requires: 'session',
     check: async (b) => {
       const opened = await b.evalValue<boolean>(
@@ -182,10 +184,32 @@ export const UI_ANCHORS: AnchorDef[] = [
       ).catch(() => false);
       if (!opened) return { ok: false, detail: 'Share button not clickable' };
       await new Promise((r) => setTimeout(r, 400));
-      const found = await hasButtonMatching(b, /handoff to claude code/i);
-      // close dropdown
+      // Legacy layout (pre 2026-06): direct "Handoff to Claude Code" menu item.
+      let found = await hasButtonMatching(b, /handoff to claude code/i);
+      if (!found) {
+        // 2026-06 layout: Share opens a tabbed dialog; handoff lives under the
+        // "Send to…" tab as a "Claude Code" destination row with a Send button.
+        // Only assert the row exists — clicking Send would mint a handoff link.
+        const tabClicked = await b.evalValue<boolean>(
+          `(() => { const tab = Array.from(document.querySelectorAll('button[role="tab"]')).find(t => /send to/i.test(t.textContent || '')); if (!tab) return false; tab.click(); return true; })()`
+        ).catch(() => false);
+        if (tabClicked) {
+          await new Promise((r) => setTimeout(r, 400));
+          found = await b.evalValue<boolean>(
+            `(() => {
+              const sends = Array.from(document.querySelectorAll('button')).filter(x => (x.textContent || '').trim() === 'Send');
+              return sends.some(x => {
+                let row = x;
+                for (let i = 0; i < 3 && row.parentElement; i++) row = row.parentElement;
+                return /claude code/i.test(row.textContent || '');
+              });
+            })()`
+          ).catch(() => false);
+        }
+      }
+      // close dialog/dropdown
       await b.evalValue<boolean>(`document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })); true`).catch(() => null);
-      return { ok: found, detail: found ? undefined : 'Share opened but no Handoff-to-Claude-Code item' };
+      return { ok: found, detail: found ? undefined : 'Share opened but no Claude Code handoff action (checked legacy item and Send to… tab)' };
     }
   },
 


### PR DESCRIPTION
## Summary
Repairs three UI-anchor drifts on claude.ai/design that broke `designer prompt` and `designer handoff`, and updates the health anchors to match the new layout. This is the fix branch for the daily-health diagnostic #49 (and the eight duplicate drift PRs closed in its favor), opened on a real branch so CI runs.

## Key Changes

### Fixes
- **Composer (`designer-controller.ts`)**: the prompt composer is now a ProseMirror contenteditable div (was a React `<textarea>`). `_submitPrompt` branches on the live element: native-setter path for textareas, synthetic-paste path for contenteditable so the editor's own pipeline ingests the text and multi-line prompts keep their line breaks.
- **Send button (`selectors.json`, `ui-anchors.ts`)**: the live DOM dropped `data-testid="chat-send-button"`; the button is now only identifiable by `title="Send (Enter)"`. Both the controller selector and the `session.sendButton` anchor match either form.
- **Handoff (`designer-controller.ts`, `ui-anchors.ts`)**: "Handoff to Claude Code" moved from a Share dropdown item to **Share → "Send to…" tab → Claude Code row → Send**. `handoff()` walks the new path (legacy menu item kept as fallback); the `share.handoffMenuItem` anchor accepts both layouts and only asserts the row exists — clicking Send would mint a handoff link on every probe.

## Technical Context
The downstream handoff logic (URL scrape → tarball fetch → extract) is unchanged: the new flow surfaces the same `api.anthropic.com/v1/design/h/…` URL in its dialog. The send-button drift was latent — yesterday's probe still passed it — so this also pre-empts tonight's health run going red on a second anchor.

## Testing Scenarios
- [x] `designer health` against live claude.ai/design: 11 ok / 0 fail (7 home anchors skipped — Chrome was on a session page; CI's two-phase nav covers them)
- [x] Real `designer handoff` on a live project: clicked the new path, fetched and extracted a 19-file bundle
- [x] Real `designer prompt` in a scratch project: multi-line prompt delivered intact via the paste path, send click fired, generation produced the requested file
- [x] `tsc --noEmit` clean; /gate (casting lens) no findings

## Related
Refs #49 — close it manually once this merges (diagnostic PRs carry no CI, so GitHub's closing keywords don't auto-close them).

---

**Generated with**: [Claude Code](https://claude.com/claude-code)