### PR TITLE
fix(setup): detect sign-in on fresh Chrome profiles (#32)

### DIFF
--- a/browser.ts
+++ b/browser.ts
@@ -29,6 +29,13 @@ export interface TabInfo {
   url: string;
 }
 
+export interface CookieInfo {
+  name: string;
+  value: string;
+  domain: string;
+  path?: string;
+}
+
 export interface Browser {
   session: string;
   run(args: string[], opts?: { input?: string; parseJson?: boolean }): Promise<string>;
@@ -38,6 +45,8 @@ export interface Browser {
   title(): Promise<string>;
   tabs(): Promise<TabInfo[]>;
   activateTab(index: number): Promise<void>;
+  reload(): Promise<string>;
+  cookies(): Promise<CookieInfo[]>;
   snapshot<T = unknown>(opts?: SnapshotOptions): Promise<T>;
   snapshotText(opts?: SnapshotOptions): Promise<string>;
   click(sel: string): Promise<string>;
@@ -70,8 +79,15 @@ export function createBrowser({
 
   function connectFlags(): string[] {
     if (!cdp) return [];
-    if (cdp === 'auto' || cdp === '1' || cdp === 'true') return ['--auto-connect'];
-    return ['--cdp', cdp];
+    // agent-browser's daemon honors --cdp only when it first creates a
+    // session; an existing session keeps its original connection and
+    // silently ignores a different --cdp endpoint (verified on 0.21.4
+    // through 0.27.2). Scope the daemon session by endpoint so designer
+    // never inherits a connection to some other Chrome — e.g. the user's
+    // own agent-browser use against a different port (issue #32 triage).
+    const scope = ['--session', `designer-cdp-${cdp.replace(/[^a-zA-Z0-9.-]/g, '_')}`];
+    if (cdp === 'auto' || cdp === '1' || cdp === 'true') return [...scope, '--auto-connect'];
+    return [...scope, '--cdp', cdp];
   }
 
   function run(
@@ -123,6 +139,15 @@ export function createBrowser({
     },
     activateTab: async (index) => {
       await run(['tab', String(index)]);
+    },
+    reload: () => run(['reload']),
+    cookies: async () => {
+      const out = await run(['cookies', 'get', '--json']);
+      const env = JSON.parse(out) as { success?: boolean; data?: { cookies?: CookieInfo[] }; error?: unknown };
+      if (env.success === false) {
+        throw new Error(`agent-browser cookies get failed: ${JSON.stringify(env.error)}`);
+      }
+      return env.data?.cookies ?? [];
     },
     snapshot: <T = unknown>({ interactive = true, scope }: SnapshotOptions = {}) => {
       const args = ['snapshot', '--json'];

--- a/setup.ts
+++ b/setup.ts
@@ -217,10 +217,35 @@ async function step3Chrome(port: string): Promise<boolean> {
     log('chrome', 'fail', `Chrome not found at ${CHROME_BIN}. Set CHROME_BIN to override.`);
     return false;
   }
-  const child = spawn(CHROME_BIN, ['--remote-debugging-port=' + port, '--user-data-dir=' + PROFILE, 'https://claude.ai/design'], {
-    detached: true,
-    stdio: 'ignore'
-  });
+  // These flags suppress first-run interstitials that otherwise swallow the
+  // command-line URL on a brand-new profile (first install, or a user who
+  // deleted theirs — issue #32). When that happens CDP comes up with ZERO
+  // page targets, so step4's agent-browser connect creates its own background
+  // tab (visibilityState=hidden) and the login poll watches a stale invisible
+  // login wall forever.
+  //   --no-first-run                   skip the first-run setup flow
+  //   --no-default-browser-check       suppress the "make Chrome default" modal
+  //   --disable-search-engine-choice-screen  suppress the EU/region search-
+  //     engine-choice screen, which is a *separate* first-run intercept the
+  //     other two flags don't cover (flagged in the #32 cross-model review;
+  //     the reporter is on Linux where this screen is most likely to appear).
+  // Defense-in-depth only: step4 still backstops a stale/wrong tab below, so a
+  // first-run surface we haven't enumerated here can't silently hang setup.
+  const child = spawn(
+    CHROME_BIN,
+    [
+      '--remote-debugging-port=' + port,
+      '--user-data-dir=' + PROFILE,
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--disable-search-engine-choice-screen',
+      'https://claude.ai/design'
+    ],
+    {
+      detached: true,
+      stdio: 'ignore'
+    }
+  );
   child.unref();
   const up = await pollUntil('chrome', () => isCdpUp(port), {
     intervalMs: 800,
@@ -244,10 +269,62 @@ async function step4SignIn(port: string): Promise<boolean> {
   await browser.open('https://claude.ai/design').catch(() => undefined);
   await sleep(2500);
 
+  // The poll can end up pinned to a stale tab the SPA never re-renders: a
+  // fresh profile's first-run swallows the launch URL, or the user completes
+  // an OAuth login in a different tab. The login succeeds (Claude's cookies
+  // are profile-wide, shared across every tab) but the watched tab stays on
+  // its logged-out snapshot — the #32 symptom: "Chrome shows up and I can
+  // login" yet the poll dots never stop.
+  //
+  // agent-browser's tab list is session-scoped (it can't see sibling tabs
+  // Chrome or OAuth opened), so switching tabs isn't an option. The robust,
+  // typing-safe signal is a profile-wide Claude auth cookie: it appears only
+  // AFTER login completes, no matter which tab was used. Gate on it, then
+  // navigate the pinned tab to claude.ai/design — a logged-in profile
+  // redirects straight through to the signed-in app. (Navigate, not reload: a
+  // stale tab could be on about:blank, which a reload leaves blank.)
+  //
+  // Two safety/robustness properties, both from the #32 cross-model review:
+  //   • Cookie presence only grants *permission to navigate*; the DOM marker
+  //     (verifySignedIn) remains the sole proof of signed-in. A stale/expired
+  //     cookie or a 2FA/onboarding redirect therefore can't false-complete
+  //     setup — we'd navigate, the marker still wouldn't appear, and the poll
+  //     keeps waiting. Match `sessionKey*` (covers sessionKey + sessionKeyV2)
+  //     so a newer auth-cookie name doesn't make recovery silently miss.
+  //   • Never navigate before the cookie exists: that's the only window in
+  //     which a half-typed login form (or an in-flight OAuth tab) could be the
+  //     thing we'd clobber.
+  //
+  // Recovery retries up to MAX_RECOVERY_NAVS (not once): the original bug is a
+  // navigation/target race, and a single latched attempt that doesn't take
+  // (slow redirect, transient network) would just create a new silent
+  // forever-poll. The poll interval is the natural backoff; the plain DOM
+  // check still runs every iteration regardless.
+  const MAX_RECOVERY_NAVS = 4;
+  const hasAuthCookie = async (): Promise<boolean> => {
+    try {
+      return (await browser.cookies()).some((c) => /^sessionKey/.test(c.name) && /claude\.ai$/.test(c.domain) && c.value.length > 20);
+    } catch {
+      return false;
+    }
+  };
+  let recoveryNavs = 0;
+  const checkSignedIn = async (): Promise<boolean> => {
+    if (await verifySignedIn(browser)) return true;
+    // Login done (cookie present) but this tab is stale: land it on design.
+    if (recoveryNavs < MAX_RECOVERY_NAVS && (await hasAuthCookie())) {
+      recoveryNavs++;
+      await browser.open('https://claude.ai/design').catch(() => undefined);
+      await sleep(3000);
+      return verifySignedIn(browser);
+    }
+    return false;
+  };
+
   // pollUntil checks the predicate before emitting any reminder — so an
   // already-signed-in session returns true on the first iteration and the
   // user never sees the sign-in prompt.
-  const ok = await pollUntil('login', () => verifySignedIn(browser), {
+  const ok = await pollUntil('login', checkSignedIn, {
     intervalMs: 2000,
     timeoutMs: 10 * 60_000,
     reminder:
@@ -256,6 +333,19 @@ async function step4SignIn(port: string): Promise<boolean> {
   });
   if (!ok) {
     log('login', 'fail', 'Timed out waiting for a signed-in claude.ai/design session. Re-run setup when ready.');
+    // Diagnostics for remote triage — #32 was undebuggable because we never
+    // knew the poll was pinned to a stale login tab. Report the watched URL
+    // and whether a Claude auth cookie exists. Note: cookies get is
+    // origin-scoped, so an off-origin watched tab (about:blank, chrome://)
+    // reads as 'absent' even if the profile has the cookie — the watched URL
+    // in this same line disambiguates that case.
+    const watched = await browser.url().catch(() => '(unreachable)');
+    const authCookie = await hasAuthCookie();
+    log(
+      'login',
+      'fail',
+      `Watched tab: ${watched} | Claude auth cookie: ${authCookie ? 'present — login succeeded but the tab stayed stale; re-run: designer setup' : 'absent (or watched tab is off claude.ai origin) — see watched URL above'}`
+    );
     return false;
   }
   const url = (await browser.url().catch(() => '')) || 'claude.ai/design';

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -46,6 +46,21 @@ async function hasButtonMatching(browser: Browser, pattern: RegExp): Promise<boo
 }
 
 export const UI_ANCHORS: AnchorDef[] = [
+  // --- login state (first so a signed-out session tops the report) ---
+  {
+    // Issue #32: signed out, `designer health` showed only skips/cryptic
+    // fails and read as "everything OK". A logged-out claude.ai/design
+    // redirects to /login — call that out explicitly.
+    id: 'login.signedIn',
+    category: 'pattern',
+    description: 'signed in (claude.ai is not showing the login wall)',
+    requires: 'any',
+    check: async (_b, url) => {
+      if (!/claude\.ai\/login/.test(url)) return { ok: true };
+      return { ok: false, detail: `signed out — Chrome is on the login wall (${url.slice(0, 80)}). Run: designer setup` };
+    }
+  },
+
   // --- home page ---
   {
     id: 'home.creator',

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -49,15 +49,37 @@ export const UI_ANCHORS: AnchorDef[] = [
   // --- login state (first so a signed-out session tops the report) ---
   {
     // Issue #32: signed out, `designer health` showed only skips/cryptic
-    // fails and read as "everything OK". A logged-out claude.ai/design
-    // redirects to /login — call that out explicitly.
+    // fails and read as "everything OK". This anchor calls the signed-out
+    // state out explicitly.
+    //
+    // A URL-only check is not enough: a logged-out visit to claude.ai/design
+    // sometimes redirects to /login, but sometimes renders the login wall AT
+    // the /design URL with no /login substring (the #16 false positive that
+    // setup's DOM-based verifier exists to catch — see setup.ts). So gate on
+    // the DOM app-shell marker setup uses, not the URL alone.
     id: 'login.signedIn',
     category: 'pattern',
-    description: 'signed in (claude.ai is not showing the login wall)',
+    description: 'signed in (claude.ai is rendering the app shell, not the login wall)',
     requires: 'any',
-    check: async (_b, url) => {
-      if (!/claude\.ai\/login/.test(url)) return { ok: true };
-      return { ok: false, detail: `signed out — Chrome is on the login wall (${url.slice(0, 80)}). Run: designer setup` };
+    check: async (b, url) => {
+      // Explicit login wall in the URL — unambiguously signed out.
+      if (/claude\.ai\/login/.test(url)) {
+        return { ok: false, detail: `signed out — Chrome is on the login wall (${url.slice(0, 80)}). Run: designer setup` };
+      }
+      // On a design surface, the signed-in app shell renders project-creator
+      // (home) or chat-composer-input (session). Their absence here means the
+      // login wall is being served at the /design URL — fail loudly.
+      if (/claude\.ai\/design/.test(url)) {
+        const signedIn =
+          (await hasSelector(b, '[data-testid="project-creator"]')) ||
+          (await hasSelector(b, '[data-testid="chat-composer-input"]'));
+        return signedIn
+          ? { ok: true }
+          : { ok: false, detail: `login wall rendered at ${url.slice(0, 80)} (no app shell) — signed out. Run: designer setup` };
+      }
+      // Off the claude.ai/design surface entirely (e.g. an unrelated tab) —
+      // sign-in can't be judged from this tab, so don't false-fail.
+      return { ok: true, detail: `not on a claude.ai/design surface (url=${url.slice(0, 60)}) — sign-in not checked here` };
     }
   },
 


### PR DESCRIPTION
Fixes #32.

## Problem

On a fresh Chrome profile (first install, or a user who deleted theirs — the #32 reporter did both), Chrome runs its **first-run flow**, which swallows the `claude.ai/design` URL passed on the command line. CDP comes up but with **zero page targets**, so when setup connects to poll for sign-in, agent-browser creates its own **hidden background tab** and the poll watches that stale, logged-out tab forever. The user signs in fine in the window Chrome eventually shows them, but setup never detects it — the exact "Chrome shows up and I can login" + endless polling dots in the issue.

Two things also made it undebuggable: `designer health` had no "are you signed in?" check (reads as all-OK when logged out), and agent-browser's daemon can keep talking to a previously-connected Chrome.

## Changes

- **`step3Chrome`** — launch Chrome with `--no-first-run`, `--no-default-browser-check`, and `--disable-search-engine-choice-screen` so the URL opens a real visible tab instead of being swallowed by a first-run interstitial.
- **`step4SignIn`** — harden the poll against a stale watched tab. agent-browser's `tab list` is session-scoped (can't see sibling tabs), so the robust signal is a profile-wide Claude auth cookie (`sessionKey*`): it appears only after login, regardless of which tab was used. When the DOM marker is absent but the cookie is present, navigate to design (**bounded retries**, not a one-shot latch). The cookie only grants *permission to navigate*; the **DOM marker stays the sole proof of signed-in**, so a stale/expired cookie or a 2FA/onboarding redirect can't false-complete setup. On timeout, print the watched URL + auth-cookie state for remote triage.
- **`browser.ts`** — scope agent-browser's daemon session per CDP endpoint (`--session designer-cdp-<port>`). The daemon ignores a different `--cdp` once a session exists (verified 0.21.4–0.27.2), so designer could inherit a connection to another Chrome. Adds `reload()` / `cookies()` helpers.
- **`ui-anchors.ts`** — add a `login.signedIn` probe (first in the report) so a signed-out session **fails loudly** instead of reading as "all OK".

## Verification

- ✅ **Fresh-profile `designer setup` end-to-end** through the real `runSetup()`: visible login window, real sign-in detected, completed to "designer is ready".
- ✅ Daemon cross-talk: two `createBrowser` instances on different ports reach their own Chromes (before: the second inherited the first's connection).
- ✅ `health` `login.signedIn`: fails loudly signed-out, passes signed-in.
- ✅ Recovery: reproduced the genuine stale state (login wall rendered, auth cookie present) — old poll hangs forever, new poll recovers to signed-in.
- ✅ Typecheck, build, and test suite green.

Hardening (search-engine-choice flag, bounded retries, `sessionKey*` matching, cookie-as-permission-not-proof) was informed by a cross-model review.

## Known follow-ups (out of scope here)

- `DESIGNER_PROFILE` override — the isolated debug profile has no password manager/passkey/extensions, which is painful when Claude auth is bound to a passkey in a password manager. An override would let users point setup at a pre-configured profile.
- Raw-CDP `Storage.getCookies` for fully origin-independent cookie reads (agent-browser's `cookies get` is current-page-scoped, so an off-origin watched tab can't see the cookie).
- A target-ID-pinned poll loop, random port vs. fixed 9222, and the security posture of a logged-in debug Chrome on a known port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)