### PR TITLE
feat(health): assert composer is fillable, not just present

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Still needs debug Chrome running (`npx -y @pro-vi/designer setup` handles it).
 - **Dedicated profile.** Chrome 136+ blocks `--remote-debugging-port` on the default profile. Login to `~/.chrome-designer-profile/` persists.
 - **Auto-launch.** MCP auto-launches debug Chrome on the first tool call if the profile exists.
 - **Bot detection.** Real Chrome + user-controlled login — not headless. Cloudflare + Google OAuth see a normal session. First login may trigger a Google new-device prompt.
+- **No password manager in the debug profile.** The dedicated profile ships with no extensions or saved logins, by design. If your Claude sign-in is bound to a passkey or password manager (e.g. a passkey stored in 1Password), it won't be available in the debug window. Use email-code login, or install your password-manager extension into the debug profile once — it persists. It's a one-time sign-in; the session sticks.
 - **`DESIGNER_CDP=9222`** is embedded in the MCP registration. Only export it in your shell if you invoke the CLI directly.
 
 ## CLI
@@ -118,7 +119,7 @@ Writes `tasting.html` with variant tabs + 1/2/3 shortcuts + persistent notes, se
 ## Operations
 
 - `designer doctor` — diagnose setup state. Exits 2 on failure.
-- `designer health [--json]` — probe 17 UI anchors. Wire into cron to catch claude.ai UI regressions.
+- `designer health [--json]` — probe every UI anchor designer depends on. Wire into cron to catch claude.ai UI regressions.
 - **Daily CI** in `.github/workflows/`: `daily-health.yml` runs the auth-required UI probe on a self-hosted macOS runner once per day; `ci.yml` typechecks + builds + does a Docker clean-room install smoke on every PR; `release-please.yml` opens a release PR on conventional commits, merging it tags + publishes via `release-publish.yml`. Selector regressions land as auto-opened PRs under the `selectors-drift` label.
 
 ## Known quirks

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Still needs debug Chrome running (`npx -y @pro-vi/designer setup` handles it).
 - **Dedicated profile.** Chrome 136+ blocks `--remote-debugging-port` on the default profile. Login to `~/.chrome-designer-profile/` persists.
 - **Auto-launch.** MCP auto-launches debug Chrome on the first tool call if the profile exists.
 - **Bot detection.** Real Chrome + user-controlled login — not headless. Cloudflare + Google OAuth see a normal session. First login may trigger a Google new-device prompt.
-- **No password manager in the debug profile.** The dedicated profile ships with no extensions or saved logins, by design. If your Claude sign-in is bound to a passkey or password manager (e.g. a passkey stored in 1Password), it won't be available in the debug window. Use email-code login, or install your password-manager extension into the debug profile once — it persists. It's a one-time sign-in; the session sticks.
 - **`DESIGNER_CDP=9222`** is embedded in the MCP registration. Only export it in your shell if you invoke the CLI directly.
 
 ## CLI

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -143,6 +143,41 @@ export const UI_ANCHORS: AnchorDef[] = [
     check: async (b) => ({ ok: await hasSelector(b, '[data-testid="chat-composer-input"]') })
   },
   {
+    // Existence (above) isn't enough — _submitPrompt can only fill a composer
+    // that is a <textarea> or a contenteditable element, and it branches on
+    // exactly that. The 2026-06 build shipped the composer as a ProseMirror
+    // contenteditable <div>; if it drifts to a shape that's neither (a bare
+    // wrapper, a web component, a readonly node), submission silently stalls
+    // and callers fall back to driving the page by hand. That's the regression
+    // fract-ai hit on a pre-0.3.9 build (designer/.inbox 2026-06-10). This
+    // anchor asserts the composer is in a shape _submitPrompt actually handles.
+    id: 'session.composerFillable',
+    category: 'session',
+    description: 'composer is fillable (textarea or contenteditable, per _submitPrompt)',
+    requires: 'session',
+    check: async (b) => {
+      type ComposerShape = { found: boolean; tag?: string; contentEditable?: boolean; fillable?: boolean };
+      const shape: ComposerShape = await b
+        .evalValue<ComposerShape>(
+          `(() => {
+            const el = document.querySelector('[data-testid="chat-composer-input"]');
+            if (!el) return { found: false };
+            const fillable = el instanceof HTMLTextAreaElement || el.isContentEditable;
+            return { found: true, tag: el.tagName, contentEditable: el.isContentEditable, fillable };
+          })()`
+        )
+        .catch((): ComposerShape => ({ found: false }));
+      if (!shape.found) return { ok: false, detail: 'composer not found' };
+      if (shape.fillable) {
+        return { ok: true, detail: shape.contentEditable ? 'contenteditable' : `<${(shape.tag || '').toLowerCase()}>` };
+      }
+      return {
+        ok: false,
+        detail: `composer is <${(shape.tag || '?').toLowerCase()}> — neither textarea nor contenteditable; _submitPrompt cannot fill it (composer shape drifted)`
+      };
+    }
+  },
+  {
     id: 'session.sendButton',
     category: 'session',
     description: 'send button',

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -151,6 +151,18 @@ export const UI_ANCHORS: AnchorDef[] = [
     // and callers fall back to driving the page by hand. That's the regression
     // fract-ai hit on a pre-0.3.9 build (designer/.inbox 2026-06-10). This
     // anchor asserts the composer is in a shape _submitPrompt actually handles.
+    //
+    // Scope: this checks the composer's SHAPE, not that a paste actually lands
+    // (verifying that would mean typing into a live session). A contenteditable
+    // whose editor rejects synthetic paste would still pass here.
+    //
+    // Maintenance: this is a block-bodied evalValue check, so it is NOT
+    // auto-heal-patchable (anchor-patcher's canPatch only rewrites the simple
+    // `hasSelector(b, '<sel>')` shape). The chat-composer-input selector is
+    // duplicated from session.promptTextarea above — if it drifts, auto-heal
+    // will self-heal promptTextarea but skip this one; update the selector in
+    // the eval below by hand to match. (Same limitation as the other rich
+    // anchors here: hasButtonMatching, iframeSrcPattern, fileListScrape.)
     id: 'session.composerFillable',
     category: 'session',
     description: 'composer is fillable (textarea or contenteditable, per _submitPrompt)',


### PR DESCRIPTION
Closes the regression-detection gap from the designer `.inbox` note (fract-ai, 2026-06-10) — "Claude Design CLI contenteditable submission regression".

## Background

fract-ai's designer-loop on 2026-06-10 couldn't submit prompts into Claude Design and fell back to driving the page directly with `agent-browser`. Root cause: the composer had become a **ProseMirror `contenteditable` div** while the published designer (≤0.3.7 at their session time, 08:33 UTC) still expected a `<textarea>`.

The **submission path itself was already fixed** in `45ff5a2` (shipped in 0.3.9, published 09:22 UTC) — `_submitPrompt` now branches on textarea vs contenteditable and delivers text via a synthetic paste. Verified live: the current code fills the ProseMirror composer correctly (paste intercepted, line breaks preserved, send button enables).

## What this PR adds

The note's one open acceptance check: **a regression/smoke check for the composer shape.** Today `session.promptTextarea` only asserts the composer *exists* — it can't catch a drift to a shape `_submitPrompt` can't fill (which is exactly what bit fract-ai).

New `session.composerFillable` anchor asserts the composer is a `<textarea>` **or** a contenteditable element — mirroring the exact branch `_submitPrompt` takes. If it drifts to neither, `designer health` now fails loudly with a clear detail instead of letting submission silently stall.

## Verification

- ✅ Live against the current ProseMirror composer: `session.composerFillable ✓ (contenteditable)`.
- ✅ Typecheck + build green.

## Release

Lands in **0.3.10** — release-please's `bump-patch-for-minor-pre-major` keeps this `feat` a patch bump, so it folds into the existing release PR #56 alongside the #32 fix.

Note: a pre-existing, unrelated `session.iframeSrcPattern` failure (design-preview iframe signed-token URL in a `_bootstrap` state) showed up during testing — not touched by this PR; flagging separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)