### PR TITLE
fix(health): settle the fileListScrape anchor to stop daily false drift

### DIFF
--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -433,9 +433,10 @@ export const UI_ANCHORS: AnchorDef[] = [
     description: 'filename text nodes detectable (listFiles scrape still works)',
     requires: 'session',
     check: async (b, url) => {
-      const result = await b
-        .evalValue<{ files: string[] }>(
-          `(() => {
+      const scrape = (): Promise<{ files: string[] }> =>
+        b
+          .evalValue<{ files: string[] }>(
+            `(() => {
             const seen = new Set();
             const files = [];
             const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
@@ -449,11 +450,29 @@ export const UI_ANCHORS: AnchorDef[] = [
             }
             return { files };
           })()`
-        )
-        .catch(() => ({ files: [] as string[] }));
-      const files = Array.isArray(result.files) ? result.files : [];
+          )
+          .catch(() => ({ files: [] as string[] }));
+
+      // The file-list panel renders a few seconds after navigation; scraping
+      // immediately races it — the recurring false "0 filenames" the daily probe
+      // filed (#64/#65/#68), even though `designer files` and a live scrape find
+      // the files once the panel is up. Retry with a bounded settle before
+      // concluding a regression.
+      let files: string[] = [];
+      for (let attempt = 0; attempt < 6; attempt++) {
+        const result = await scrape();
+        files = Array.isArray(result.files) ? result.files : [];
+        if (files.length > 0) break;
+        if (attempt < 5) await sleep(1000);
+      }
       if (files.length === 0) {
-        return { ok: false, detail: 'found 0 filenames — scraper regex or DOM layout regressed' };
+        // With no file open the file-list panel may legitimately be absent — don't
+        // hard-fail a soft anchor on an inconclusive state; only a populated
+        // session (a file open) is expected to list filenames.
+        if (!/[?&]file=/.test(url)) {
+          return { ok: true, status: 'skip', detail: 'no file open; file-list panel not rendered — inconclusive' };
+        }
+        return { ok: false, detail: 'found 0 filenames after ~5s settle — scraper regex or DOM layout regressed' };
       }
       const match = url.match(/[?&]file=([^&]+)/);
       if (match && match[1]) {


### PR DESCRIPTION
The daily health probe has filed a "selector drift detected" PR (#64/#65/#68) every day on a single anchor — `session.fileListScrape` "found 0 filenames" — for a scraper that isn't actually broken.

## Root cause (verified live)
`session.fileListScrape` walks `document.body` text nodes for filename-pattern text **once, immediately**, and fails on 0. But the file-list panel renders a few seconds after navigation, so the probe races it. In the probe's exact state (a file open on project `72e73856`), a live scrape finds **all 3 files**, and `designer files` returns them — the panel simply hadn't rendered when the probe scraped. It's a render-timing flake, not a moved selector. (`fileListScrape` is a soft, corroboration-only anchor per `CLAUDE.md`.)

Same shape as the entry-layer drift, one level down: the anchor's model (scrape now) didn't match render reality (panel appears after a delay).

## Fix
- **Settle/retry**: scrape up to 6 times (~5s) before concluding a regression — a render race no longer reads as drift.
- **Skip when inconclusive**: with no file open the panel may legitimately be absent, so return `skip` (not `fail`) — only a file-open session is expected to list filenames. The active-file sub-check is unchanged.

## Verification
- ✅ `npm run check` (tsc) · `npm test` 28/28
- Live: the scraper finds all 3 files once the panel renders (the settle covers the race); `designer files` already returned them.

Closes the daily-noise loop; #64/#65/#68 were all this same false positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)