### PR TITLE
refactor: extract isCdpEnabled to cdp-env, share asRec from cdp-trace

### DIFF
--- a/cdp-ensure.ts
+++ b/cdp-ensure.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { defaultChromeBin, isChromeRunning, QUIT_CHROME_HINT } from './cross-platform.ts';
+import { isCdpEnabled } from './cdp-env.ts';
 
 const PORT = process.env.DESIGNER_CDP || '9222';
 const PROFILE = path.join(os.homedir(), '.chrome-designer-profile');
@@ -31,7 +32,7 @@ export async function ensureCdpUp(): Promise<void> {
   // Respect the explicit opt-out (DESIGNER_CDP=''): never probe or auto-launch
   // the debug Chrome for a user who chose the agent-browser session-managed flow.
   // Throwing here makes any stray CdpSession.attach() degrade to null cleanly.
-  if (process.env.DESIGNER_CDP === '') {
+  if (!isCdpEnabled()) {
     throw new Error("CDP explicitly disabled (DESIGNER_CDP=''); using the agent-browser session-managed flow.");
   }
   if (await isCdpUp()) return;

--- a/cdp-env.ts
+++ b/cdp-env.ts
@@ -1,0 +1,15 @@
+// Shared resolution of the DESIGNER_CDP opt-out.
+//
+// DESIGNER_CDP has THREE states (see CLAUDE.md): unset or '9222' = CDP on,
+// '' = OFF (the agent-browser session-managed flow). The opt-out is enforced at
+// the GATES (controller attach, the turn-RPC canary, ensureCdpUp), not in the
+// port constants — `browser.ts` resolves the port with `??` (honors '') while
+// `cdp-trace.ts`/`cdp-ensure.ts` use `|| '9222'` (do NOT honor ''), by design.
+//
+// This is the single definition of "is CDP work allowed", so the load-bearing
+// gate can't drift across its call sites (it was inlined in designer-controller
+// 4× and, inverted, in ui-anchors). Pure, no I/O — reads the env at call time so
+// a test or runtime toggle is honored.
+export function isCdpEnabled(): boolean {
+  return (process.env.DESIGNER_CDP ?? '9222') !== '';
+}

--- a/cdp-trace.ts
+++ b/cdp-trace.ts
@@ -126,7 +126,9 @@ const PERSIST_METHODS = new Set([
   'Page.lifecycleEvent'
 ]);
 
-function asRec(v: unknown): Record<string, unknown> {
+// Narrow an unknown CDP payload to a record before keyed access. Shared by the
+// CDP subclasses (run-state, oopif-reader) that parse event/response shapes.
+export function asRec(v: unknown): Record<string, unknown> {
   return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
 }
 

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -11,6 +11,7 @@ import { ensureCdpUp } from './cdp-ensure.ts';
 import { RunStateObserver } from './run-state.ts';
 import { OopifHtmlReader } from './oopif-reader.ts';
 import { isPreviewIframeSrc, previewIframeVariant } from './preview-host.ts';
+import { isCdpEnabled } from './cdp-env.ts';
 
 export interface Selectors {
   login: { signedInIndicator: string | null };
@@ -116,13 +117,6 @@ export interface RepairReport {
 }
 
 const DESIGN_HOME = 'https://claude.ai/design';
-
-// The DESIGNER_CDP opt-out (CLAUDE.md: three states — unset/9222 = on, '' = off,
-// the agent-browser session-managed flow). One definition of "is CDP work
-// allowed" so the load-bearing gate can't drift across its call sites.
-function isCdpEnabled(): boolean {
-  return (process.env.DESIGNER_CDP ?? '9222') !== '';
-}
 
 // A claude.ai/design session URL: /design/p/<uuid>. Capture group 1 is the
 // project id. Used by isInSession()-style checks and `adopt` (binding an
@@ -1028,6 +1022,13 @@ export class DesignerController {
   //     degrades to the node fetch on any failure, so every existing caller
   //     (snapshot, iterate's post-gen snapshot, the no_change signal, and the
   //     _waitForGenerationDoneHtml fallback) behaves at least as before.
+  //
+  // CONTRACT: "served HTML" here is the preview's RENDERED DOM (outerHTML in the
+  // bootstrap regime; the served response body in the signed-token regime), NOT
+  // the on-disk source file. For the byte-stability / no_change / snapshot uses
+  // that is exactly right (they care what the preview shows). A caller that needs
+  // authoritative file SOURCE must use `handoff` (the Share/Export bundle), not
+  // this. Returns html:'' (never the loader shell) when no real HTML is readable.
   async fetchServedHtml(sharedReader?: OopifHtmlReader | null): Promise<{ src: string; html: string }> {
     const src = await this.getIframeSrc();
     if (!src || !isPreviewIframeSrc(src)) return { src: '', html: '' };

--- a/oopif-reader.ts
+++ b/oopif-reader.ts
@@ -1,4 +1,4 @@
-import { CdpSession, type CdpSessionOptions, type CdpTarget } from './cdp-trace.ts';
+import { CdpSession, asRec, type CdpSessionOptions, type CdpTarget } from './cdp-trace.ts';
 import { isPreviewIframeSrc } from './preview-host.ts';
 
 // OOPIF preview-HTML reader (issue #61 / PR #66 review #4, live-verified; hardened
@@ -49,10 +49,6 @@ export interface CaptureOopifHtmlOpts {
   pollMs?: number;
   sendTimeoutMs?: number;
   now?: () => number;
-}
-
-function asRec(v: unknown): Record<string, unknown> {
-  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
 }
 
 function evaluatedString(result: unknown): string | null {

--- a/run-state.ts
+++ b/run-state.ts
@@ -1,4 +1,4 @@
-import { CdpSession, type CdpSessionOptions, type CdpTarget } from './cdp-trace.ts';
+import { CdpSession, asRec, type CdpSessionOptions, type CdpTarget } from './cdp-trace.ts';
 
 export const OMELETTE_TURN_SERVICE = 'anthropic.omelette.api.v1alpha.OmeletteService';
 export const TURN_RPCS = ['Chat', 'RenewTurn', 'ReleaseTurn'] as const;
@@ -13,10 +13,6 @@ export type RunSignal =
   | { kind: 'release'; requestId?: string }
   | { kind: 'critical-error'; rpc: CriticalRunRpc; status: number | 'failed' }
   | { kind: 'observer-lost' };
-
-function asRec(v: unknown): Record<string, unknown> {
-  return v && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
-}
 
 function num(v: unknown): number | null {
   return typeof v === 'number' && Number.isFinite(v) ? v : null;

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -1,6 +1,7 @@
 import type { Browser } from './browser.ts';
 import { RunStateObserver } from './run-state.ts';
 import { isPreviewIframeSrc, previewIframeVariant } from './preview-host.ts';
+import { isCdpEnabled } from './cdp-env.ts';
 
 // Every UI anchor this MCP depends on to work. Grouped by the surface state
 // they live on. A regression in Claude Design's UI will trip one or more of
@@ -116,7 +117,7 @@ async function checkTurnRpcContract(_browser: Browser, currentUrl: string): Prom
   if (process.env.DESIGNER_TURN_RPC_CANARY !== '1') {
     return { ok: true, status: 'skip', detail: 'turn-RPC canary disabled (DESIGNER_TURN_RPC_CANARY!=1)' };
   }
-  if ((process.env.DESIGNER_CDP ?? '9222') === '') {
+  if (!isCdpEnabled()) {
     return { ok: true, status: 'skip', detail: "CDP disabled (DESIGNER_CDP=''); turn-RPC canary not probed" };
   }
   const observer = await RunStateObserver.attach({ preferUrlPrefix: currentUrl.split('?')[0] || null });


### PR DESCRIPTION
## What

Consolidate the idiom duplication flagged when #67 merged (the deferred *"shared cdp-env/util module"* follow-up). Behavior-preserving — identical expressions centralized.

- **`isCdpEnabled()` → new `cdp-env.ts`.** The `DESIGNER_CDP` opt-out check (`(env ?? '9222') !== ''`) was inlined in `designer-controller` (4× via a local helper) and, inverted (`=== ''`), in `ui-anchors` and `cdp-ensure`. Now one definition of the load-bearing gate; consumers import it.
  - Port-resolution constants (`browser.ts` `??`, `cdp-trace`/`cdp-ensure` `||`) are **intentionally left as-is** per CLAUDE.md — only the opt-out *check* is consolidated, not the port operators (that operator difference is by design).
- **`asRec()` → exported from `cdp-trace.ts`** (its existing home), imported by `run-state.ts` and `oopif-reader.ts`; drops two identical copies.
- **`fetchServedHtml`**: documented the *"served = RENDERED DOM, not file source"* contract so a future caller doesn't mistake it for `handoff`.

## Verification

`tsc` clean, `npm test` 44/44. Completeness + sibling sweep: the opt-out check now lives **only** in `cdp-env.ts`, `asRec` **only** in `cdp-trace.ts`. Live `designer health` unchanged (13 ok / 1 fail / 7 skip — the 1 fail is `chatTurnPrefix`, fixed separately in #71).

## Deferred (still)

An explicit regime marker on `fetchServedHtml` + controller-seam tests — both fight the repo's "browser-coupled methods aren't unit-tested (need live Chrome)" convention; not worth the dependency-injection churn now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)