### PR TITLE
feat: interstitial pre-flight + OOPIF/interstitial health probes + 2026-06 selector-drift repair

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -73,7 +73,7 @@ async function main(): Promise<void> {
     }
     case 'session': {
       const c = new DesignerController({ key });
-      const action = (flags.action as 'status' | 'ensure_ready' | 'resume' | 'create' | 'adopt') || 'status';
+      const action = (flags.action as 'status' | 'ensure_ready' | 'resume' | 'create' | 'adopt' | 'clear') || 'status';
       const name = flags.name as string | undefined;
       const fidelity = flags.fidelity as 'wireframe' | 'highfi' | undefined;
       console.log(JSON.stringify(await c.session({ action, name, fidelity }), null, 2));
@@ -110,6 +110,11 @@ async function main(): Promise<void> {
       const name = (flags.name as string) || (flags._[0] as string | undefined);
       const c = new DesignerController({ key });
       console.log(JSON.stringify(await c.adoptSession(name), null, 2));
+      break;
+    }
+    case 'clear': {
+      const c = new DesignerController({ key });
+      console.log(JSON.stringify(await c.clearInterstitials(), null, 2));
       break;
     }
     case 'snapshot': {
@@ -332,6 +337,7 @@ Session lifecycle:
                                                enter/inspect/transition (primary entry)
   adopt [name] [--key k]                        bind the open /design/p/<uuid> tab to a key
                                                (use when the creation-cards home can't be driven)
+  clear [--key k]                              dismiss interstitials (token banner / error / Cloudflare)
   status [--key k]                             read stored state
   list                                         list locally-tracked sessions
   close [--key k]                              close browser (state preserved)
@@ -369,7 +375,7 @@ const HELP: Record<string, string> = {
   session: `designer session — enter, inspect, or transition a claude.ai/design session.
 
 Flags:
-  --action <a>    status (default, read-only) | ensure_ready | resume | create | adopt
+  --action <a>    status (default, read-only) | ensure_ready | resume | create | adopt | clear
   --name <N>      required when --action create; optional label when --action adopt
   --fidelity <f>  wireframe | highfi (default wireframe) — folded into the creation
                   seed prompt as a directive (the redesigned home has no fidelity toggle)

--- a/cli.ts
+++ b/cli.ts
@@ -113,8 +113,10 @@ async function main(): Promise<void> {
       break;
     }
     case 'clear': {
+      // Route through session({action:'clear'}) so it selects THIS key's tab
+      // before clearing (multi-key safety — PR #77 Codex P2), same as MCP.
       const c = new DesignerController({ key });
-      console.log(JSON.stringify(await c.clearInterstitials(), null, 2));
+      console.log(JSON.stringify(await c.session({ action: 'clear' }), null, 2));
       break;
     }
     case 'snapshot': {

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -15,7 +15,9 @@ import { isCdpEnabled } from './cdp-env.ts';
 import {
   classifyInterstitial,
   plannedAction,
+  isBlockingInterstitial,
   CONTINUE_HERE_TEXT,
+  INTERSTITIAL_PROBE_EXPR,
   type InterstitialKind,
   type InterstitialProbe,
   type InterstitialReport
@@ -344,80 +346,109 @@ export class DesignerController {
   // through ensureReady so these don't silently stall automation or get misread
   // as a finished / context-ceilinged generation.
 
-  // Read the page content the classifier needs in a single eval. Best-effort:
-  // a failed/odd page degrades to empty (classified as "no interstitial").
-  async _probeInterstitial(): Promise<InterstitialProbe> {
-    return (
-      (await this.browser
-        .evalValue<InterstitialProbe>(
-          `(() => ({
-            bodyText: ((document.body && document.body.innerText) || '').slice(0, 20000),
-            buttonTexts: Array.from(document.querySelectorAll('button'))
-              .map((b) => (b.textContent || '').trim())
-              .filter(Boolean)
-              .slice(0, 300)
-          }))()`
-        )
-        .catch(() => ({ bodyText: '', buttonTexts: [] }))) || { bodyText: '', buttonTexts: [] }
-    );
+  // Read the page content the classifier needs in a single eval, via the shared
+  // INTERSTITIAL_PROBE_EXPR (same shape as the CI diagnostic). Returns null when
+  // the read FAILS — distinct from a successfully-read clear page — so callers
+  // never mistake "couldn't read" for "no interstitial" (review #5a).
+  async _probeInterstitial(): Promise<InterstitialProbe | null> {
+    return this.browser.evalValue<InterstitialProbe>(INTERSTITIAL_PROBE_EXPR).catch(() => null);
+  }
+
+  // Classify the page now, threading the configured token-banner button text so
+  // detection and the click stay on one source of truth (review #3b). Returns
+  // null on an unreadable page (probe failure) OR a clear page — callers that
+  // must distinguish the two re-probe explicitly.
+  private async _classifyNow(): Promise<InterstitialKind | null> {
+    const probe = await this._probeInterstitial();
+    return probe ? classifyInterstitial(probe, { continueHere: this.selectors.interstitials?.continueHere }) : null;
   }
 
   // Detect and clear interstitials on the currently-bound tab. Loops because
   // clearing one can reveal another (a reload can land back on the token banner),
-  // and a click/reload needs a re-probe to confirm. Cloudflare can't be solved
-  // programmatically, so we wait for it to self-clear and otherwise report it as
-  // `blocked` for the caller to surface to a human.
+  // and each action re-probes to CONFIRM before counting it handled. Blocking
+  // kinds (cloudflare, transient-error) that survive are reported `blocked`; the
+  // token banner is non-blocking (the shell stays usable) so it never blocks a
+  // verb even if its button can't be clicked (review #3 / #6). ensureCdpUp first
+  // so the standalone `designer clear` fails loud on a dead Chrome instead of
+  // reporting a false recovery (review #5b).
   async clearInterstitials({
     maxPasses = 4,
     cloudflareWaitMs = 25_000,
     pollMs = 1500
   }: { maxPasses?: number; cloudflareWaitMs?: number; pollMs?: number } = {}): Promise<InterstitialReport> {
+    await ensureCdpUp();
     const handled: InterstitialKind[] = [];
     for (let pass = 0; pass < maxPasses; pass++) {
-      const kind = classifyInterstitial(await this._probeInterstitial());
+      const kind = await this._classifyNow();
       if (!kind) return { ok: true, handled, blocked: null };
       const action = plannedAction(kind);
 
       if (action === 'click-continue') {
+        // Benign banner: try to dismiss, but never block the verb on it.
         const text = this.selectors.interstitials?.continueHere || CONTINUE_HERE_TEXT;
-        const clicked = await this._clickButtonByText(new RegExp(`^${escapeRegExp(text)}$`)).catch(() => false);
-        if (!clicked) break; // banner present but its button vanished — report residual below
-        handled.push(kind);
-        appendHistory(this.key, { kind: 'interstitial', interstitial: kind, action });
-        await new Promise((r) => setTimeout(r, 600));
-        continue;
+        const clicked = await this._clickButtonByText(new RegExp(`^${escapeRegExp(text)}$`, 'i')).catch(() => false);
+        if (clicked) {
+          await new Promise((r) => setTimeout(r, 600));
+          if ((await this._classifyNow()) !== kind) {
+            handled.push(kind);
+            appendHistory(this.key, { kind: 'interstitial', interstitial: kind, action });
+            continue; // cleared — loop to catch any newly-revealed interstitial
+          }
+        }
+        appendHistory(this.key, {
+          kind: 'interstitial',
+          interstitial: kind,
+          action: clicked ? 'uncleared-nonblocking' : 'continue-button-missing'
+        });
+        return { ok: true, handled, blocked: null };
       }
 
       if (action === 'reload') {
-        handled.push(kind);
+        const u = await this.currentUrl();
+        if (!u) break; // can't reload an unknown URL (review #4) — fall to residual
         appendHistory(this.key, { kind: 'interstitial', interstitial: kind, action });
-        await this.browser.open(await this.currentUrl()).catch(() => null);
-        await this.browser.waitLoad('networkidle').catch(() => null);
+        await this.browser.open(u).catch(() => null);
+        // 'load', not 'networkidle' — the SPA's persistent connections never go
+        // idle, so networkidle would burn the full timeout each pass (review #4).
+        await this.browser.waitLoad('load').catch(() => null);
         await new Promise((r) => setTimeout(r, 800));
-        continue;
+        continue; // confirm on the next pass's probe
       }
 
-      // await-human (cloudflare): wait for the challenge to self-clear before
-      // declaring it blocked — it frequently resolves on its own.
-      const cleared = await this._waitForInterstitialClear(kind, cloudflareWaitMs, pollMs);
-      appendHistory(this.key, { kind: 'interstitial', interstitial: kind, action: cleared ? 'cleared-after-wait' : 'blocked' });
-      if (cleared) {
-        handled.push(kind);
-        continue;
+      if (action === 'await-human') {
+        // Cloudflare can't be solved programmatically; wait for it to self-clear
+        // before declaring it blocked — it frequently resolves on its own.
+        const cleared = await this._waitForInterstitialClear(kind, cloudflareWaitMs, pollMs);
+        appendHistory(this.key, { kind: 'interstitial', interstitial: kind, action: cleared ? 'cleared-after-wait' : 'blocked' });
+        if (cleared) {
+          handled.push(kind);
+          continue;
+        }
+        return { ok: false, handled, blocked: kind };
       }
-      return { ok: false, handled, blocked: kind };
+
+      // Exhaustiveness: a new InterstitialAction must be handled above, not fall
+      // silently into one of the branches (review below-gate).
+      const _exhaustive: never = action;
+      return _exhaustive;
     }
-    const residual = classifyInterstitial(await this._probeInterstitial());
-    return { ok: !residual, handled, blocked: residual };
+    // maxPasses exhausted (e.g. a transient error that survived every reload).
+    const residual = await this._classifyNow();
+    if (residual && isBlockingInterstitial(residual)) return { ok: false, handled, blocked: residual };
+    return { ok: true, handled, blocked: null };
   }
 
   private async _waitForInterstitialClear(kind: InterstitialKind, timeoutMs: number, pollMs: number): Promise<boolean> {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
       await new Promise((r) => setTimeout(r, pollMs));
-      // A change to a *different* interstitial also counts as cleared — the outer
-      // loop re-probes and handles whatever is now on top.
-      if (classifyInterstitial(await this._probeInterstitial()) !== kind) return true;
+      const probe = await this._probeInterstitial();
+      // A FAILED read (null probe) is NOT "cleared" — keep waiting (review #5a).
+      // Only a successful read that classifies as a different kind (or clear)
+      // means the challenge is gone; the outer loop handles whatever's now on top.
+      if (probe && classifyInterstitial(probe, { continueHere: this.selectors.interstitials?.continueHere }) !== kind) {
+        return true;
+      }
     }
     return false;
   }
@@ -449,7 +480,16 @@ export class DesignerController {
     // transient-error or Cloudflare overlay HIDES those anchors, so a real design
     // tab can be masked. Before falling back to opening home, activate the best
     // design tab and try clearing; a successful clear re-exposes the anchors.
-    const designTabs = await this.candidateTabs((u) => /^https:\/\/claude\.ai\/design(\/|$|\?)/.test(u));
+    //
+    // SCOPE to the stored project (mirror selectMatchingTab): an unscoped /design
+    // filter would activate the lowest-index design tab — potentially an UNRELATED
+    // project — and a later clear/fall-through could silently bind this key to it
+    // (review #2, cross-project contamination). Only widen to any /design tab when
+    // this key has no stored project to be wrong about.
+    const recoveryRoot = getSession(this.key)?.designUrl?.split('?')[0];
+    const designTabs = await this.candidateTabs((u) =>
+      recoveryRoot ? u.startsWith(recoveryRoot) : /^https:\/\/claude\.ai\/design(\/|$|\?)/.test(u)
+    );
     if (designTabs.length > 0) {
       await this.browser.activateTab(designTabs[0]!.index).catch(() => null);
       const report = await this.clearInterstitials();

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -354,13 +354,17 @@ export class DesignerController {
     return this.browser.evalValue<InterstitialProbe>(INTERSTITIAL_PROBE_EXPR).catch(() => null);
   }
 
-  // Classify the page now, threading the configured token-banner button text so
-  // detection and the click stay on one source of truth (review #3b). Returns
-  // null on an unreadable page (probe failure) OR a clear page — callers that
-  // must distinguish the two re-probe explicitly.
+  // The configured token-banner button text, threaded into every classify call so
+  // detection and the click stay on one source of truth (review #3b).
+  private get _classifyOpts(): { continueHere?: string } {
+    return { continueHere: this.selectors.interstitials?.continueHere };
+  }
+
+  // Classify the page now. Returns null on an unreadable page (probe failure) OR
+  // a clear page — callers that must distinguish the two re-probe explicitly.
   private async _classifyNow(): Promise<InterstitialKind | null> {
     const probe = await this._probeInterstitial();
-    return probe ? classifyInterstitial(probe, { continueHere: this.selectors.interstitials?.continueHere }) : null;
+    return probe ? classifyInterstitial(probe, this._classifyOpts) : null;
   }
 
   // Detect and clear interstitials on the currently-bound tab. Loops because
@@ -446,7 +450,7 @@ export class DesignerController {
       // A FAILED read (null probe) is NOT "cleared" — keep waiting (review #5a).
       // Only a successful read that classifies as a different kind (or clear)
       // means the challenge is gone; the outer loop handles whatever's now on top.
-      if (probe && classifyInterstitial(probe, { continueHere: this.selectors.interstitials?.continueHere }) !== kind) {
+      if (probe && classifyInterstitial(probe, this._classifyOpts) !== kind) {
         return true;
       }
     }
@@ -490,8 +494,9 @@ export class DesignerController {
     const designTabs = await this.candidateTabs((u) =>
       recoveryRoot ? u.startsWith(recoveryRoot) : /^https:\/\/claude\.ai\/design(\/|$|\?)/.test(u)
     );
-    if (designTabs.length > 0) {
-      await this.browser.activateTab(designTabs[0]!.index).catch(() => null);
+    const recoveryTab = designTabs[0];
+    if (recoveryTab) {
+      await this.browser.activateTab(recoveryTab.index).catch(() => null);
       const report = await this.clearInterstitials();
       if (report.blocked) throw this._interstitialError(report.blocked, designTabs.length);
       if (report.handled.length > 0) {

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -245,7 +245,16 @@ export class DesignerController {
       // first (scoped, activate-only — no navigation, so it won't hijack another
       // key's tab) so the clear targets the requested session (PR #77 Codex P2).
       if (isCdpEnabled()) await ensureCdpUp();
-      await this.selectMatchingTab().catch(() => null);
+      const picked = await this.selectMatchingTab().catch(() => ({ matched: false, candidates: 0 }));
+      // candidates===0 means NO tab matches this key — selectMatchingTab didn't
+      // activate anything, so the browser is still bound to whatever was active.
+      // Refuse rather than clear (click/reload) an unrelated key's tab (PR #77
+      // Codex P2). candidates>0 means this key's tab is bound (matched, or
+      // present-but-masked by the very interstitial we're here to clear) → proceed.
+      if (picked.candidates === 0) {
+        const report: InterstitialReport = { ok: true, handled: [], blocked: null };
+        return { ...report, matched: false, note: 'no live tab matches this key — nothing to clear', status: await this.getStatus() };
+      }
       const r = await this.clearInterstitials();
       return { ...r, status: await this.getStatus() };
     }

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -992,16 +992,19 @@ export class DesignerController {
     }
 
     // Open the Design Files dialog to get the richer file/folder listing.
-    // Idempotent — if already open, the click is a no-op (or toggles; we
-    // accept the occasional toggle as the tradeoff for not probing state).
+    // Click the label directly: React attaches handlers via root delegation, so
+    // the old walk-up-for-non-null-.onclick exhausted to null and never fired —
+    // a latent no-op that left this scrape seeing only bare-page filenames. A
+    // click on the label bubbles to React's delegated handler. Kept identical to
+    // the session.fileListScrape health anchor's opener so the probe exercises
+    // the SAME path production uses (PR #77 Codex P2). Idempotent — if already
+    // open it may toggle; we accept the occasional toggle vs probing panel state.
     await this.browser.evalValue<boolean>(
       `(() => {
         const spans = Array.from(document.querySelectorAll('span'));
         const label = spans.find(s => s.children.length === 0 && (s.textContent || '').trim() === 'Design Files');
         if (!label) return false;
-        let row = label;
-        while (row && row.onclick === null) row = row.parentElement;
-        if (row) row.click();
+        label.click();
         return true;
       })()`
     ).catch(() => null);

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -12,6 +12,14 @@ import { RunStateObserver } from './run-state.ts';
 import { OopifHtmlReader } from './oopif-reader.ts';
 import { isPreviewIframeSrc, previewIframeVariant } from './preview-host.ts';
 import { isCdpEnabled } from './cdp-env.ts';
+import {
+  classifyInterstitial,
+  plannedAction,
+  CONTINUE_HERE_TEXT,
+  type InterstitialKind,
+  type InterstitialProbe,
+  type InterstitialReport
+} from './interstitials.ts';
 
 export interface Selectors {
   login: { signedInIndicator: string | null };
@@ -41,6 +49,10 @@ export interface Selectors {
     chatMessagesContainer: string;
     generatingIndicator: string | null;
   };
+  // Content-only interstitial overlays have no stable testid; detection regexes
+  // live in interstitials.ts. This optional block lets the one actionable button
+  // text be overridden alongside the other anchors (~/.designer/selectors.override.json).
+  interstitials?: { continueHere?: string };
   [k: string]: unknown;
 }
 
@@ -214,10 +226,18 @@ export class DesignerController {
     action = 'status',
     name,
     fidelity = 'wireframe'
-  }: { action?: 'status' | 'ensure_ready' | 'resume' | 'create' | 'adopt'; name?: string; fidelity?: 'wireframe' | 'highfi' } = {}): Promise<unknown> {
+  }: {
+    action?: 'status' | 'ensure_ready' | 'resume' | 'create' | 'adopt' | 'clear';
+    name?: string;
+    fidelity?: 'wireframe' | 'highfi';
+  } = {}): Promise<unknown> {
     if (action === 'status') return this.getStatus();
     if (action === 'ensure_ready') {
       const r = await this.ensureReady();
+      return { ...r, status: await this.getStatus() };
+    }
+    if (action === 'clear') {
+      const r = await this.clearInterstitials();
       return { ...r, status: await this.getStatus() };
     }
     if (action === 'resume') {
@@ -317,12 +337,129 @@ export class DesignerController {
     return { matched: false, candidates: candidates.length };
   }
 
-  async ensureReady(): Promise<{ ok: true; url: string; inSession: boolean }> {
+  // --- interstitial pre-flight (see interstitials.ts) -----------------------
+  // claude.ai/design interrupts the flow with content-only overlays that carry
+  // no data-testid: the 495k-token "Continue here" banner, a transient "Something
+  // went wrong" page, and the Cloudflare bot-check. Verbs run clearInterstitials()
+  // through ensureReady so these don't silently stall automation or get misread
+  // as a finished / context-ceilinged generation.
+
+  // Read the page content the classifier needs in a single eval. Best-effort:
+  // a failed/odd page degrades to empty (classified as "no interstitial").
+  async _probeInterstitial(): Promise<InterstitialProbe> {
+    return (
+      (await this.browser
+        .evalValue<InterstitialProbe>(
+          `(() => ({
+            bodyText: ((document.body && document.body.innerText) || '').slice(0, 20000),
+            buttonTexts: Array.from(document.querySelectorAll('button'))
+              .map((b) => (b.textContent || '').trim())
+              .filter(Boolean)
+              .slice(0, 300)
+          }))()`
+        )
+        .catch(() => ({ bodyText: '', buttonTexts: [] }))) || { bodyText: '', buttonTexts: [] }
+    );
+  }
+
+  // Detect and clear interstitials on the currently-bound tab. Loops because
+  // clearing one can reveal another (a reload can land back on the token banner),
+  // and a click/reload needs a re-probe to confirm. Cloudflare can't be solved
+  // programmatically, so we wait for it to self-clear and otherwise report it as
+  // `blocked` for the caller to surface to a human.
+  async clearInterstitials({
+    maxPasses = 4,
+    cloudflareWaitMs = 25_000,
+    pollMs = 1500
+  }: { maxPasses?: number; cloudflareWaitMs?: number; pollMs?: number } = {}): Promise<InterstitialReport> {
+    const handled: InterstitialKind[] = [];
+    for (let pass = 0; pass < maxPasses; pass++) {
+      const kind = classifyInterstitial(await this._probeInterstitial());
+      if (!kind) return { ok: true, handled, blocked: null };
+      const action = plannedAction(kind);
+
+      if (action === 'click-continue') {
+        const text = this.selectors.interstitials?.continueHere || CONTINUE_HERE_TEXT;
+        const clicked = await this._clickButtonByText(new RegExp(`^${escapeRegExp(text)}$`)).catch(() => false);
+        if (!clicked) break; // banner present but its button vanished — report residual below
+        handled.push(kind);
+        appendHistory(this.key, { kind: 'interstitial', interstitial: kind, action });
+        await new Promise((r) => setTimeout(r, 600));
+        continue;
+      }
+
+      if (action === 'reload') {
+        handled.push(kind);
+        appendHistory(this.key, { kind: 'interstitial', interstitial: kind, action });
+        await this.browser.open(await this.currentUrl()).catch(() => null);
+        await this.browser.waitLoad('networkidle').catch(() => null);
+        await new Promise((r) => setTimeout(r, 800));
+        continue;
+      }
+
+      // await-human (cloudflare): wait for the challenge to self-clear before
+      // declaring it blocked — it frequently resolves on its own.
+      const cleared = await this._waitForInterstitialClear(kind, cloudflareWaitMs, pollMs);
+      appendHistory(this.key, { kind: 'interstitial', interstitial: kind, action: cleared ? 'cleared-after-wait' : 'blocked' });
+      if (cleared) {
+        handled.push(kind);
+        continue;
+      }
+      return { ok: false, handled, blocked: kind };
+    }
+    const residual = classifyInterstitial(await this._probeInterstitial());
+    return { ok: !residual, handled, blocked: residual };
+  }
+
+  private async _waitForInterstitialClear(kind: InterstitialKind, timeoutMs: number, pollMs: number): Promise<boolean> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      await new Promise((r) => setTimeout(r, pollMs));
+      // A change to a *different* interstitial also counts as cleared — the outer
+      // loop re-probes and handles whatever is now on top.
+      if (classifyInterstitial(await this._probeInterstitial()) !== kind) return true;
+    }
+    return false;
+  }
+
+  private _interstitialError(kind: InterstitialKind, candidates: number): Error {
+    const suffix = candidates > 0 ? ` (checked ${candidates} tab(s))` : '';
+    if (kind === 'cloudflare') {
+      return new Error(
+        `Cloudflare bot-check is up on claude.ai/design and didn't clear${suffix}. ` +
+          `Solve it in the CDP-attached Chrome, then retry.`
+      );
+    }
+    return new Error(`Unresolved interstitial '${kind}' on claude.ai/design${suffix}.`);
+  }
+
+  async ensureReady(): Promise<{ ok: true; url: string; inSession: boolean; interstitials?: InterstitialReport }> {
     await ensureCdpUp();
 
     const picked = await this.selectMatchingTab();
     if (picked.matched) {
-      return { ok: true, url: await this.currentUrl(), inSession: await this.isInSession() };
+      // The token banner leaves the composer visible, so a tab can match with an
+      // interstitial still up — clear it before any verb runs against the page.
+      const interstitials = await this.clearInterstitials();
+      if (interstitials.blocked) throw this._interstitialError(interstitials.blocked, picked.candidates);
+      return { ok: true, url: await this.currentUrl(), inSession: await this.isInSession(), interstitials };
+    }
+
+    // selectMatchingTab matches on a visible composer/home anchor — but a
+    // transient-error or Cloudflare overlay HIDES those anchors, so a real design
+    // tab can be masked. Before falling back to opening home, activate the best
+    // design tab and try clearing; a successful clear re-exposes the anchors.
+    const designTabs = await this.candidateTabs((u) => /^https:\/\/claude\.ai\/design(\/|$|\?)/.test(u));
+    if (designTabs.length > 0) {
+      await this.browser.activateTab(designTabs[0]!.index).catch(() => null);
+      const report = await this.clearInterstitials();
+      if (report.blocked) throw this._interstitialError(report.blocked, designTabs.length);
+      if (report.handled.length > 0) {
+        const retry = await this.selectMatchingTab();
+        if (retry.matched) {
+          return { ok: true, url: await this.currentUrl(), inSession: await this.isInSession(), interstitials: report };
+        }
+      }
     }
 
     // No live design tab matched. Fall back to opening home and re-checking.
@@ -334,6 +471,9 @@ export class DesignerController {
       }
     }
 
+    const interstitials = await this.clearInterstitials();
+    if (interstitials.blocked) throw this._interstitialError(interstitials.blocked, picked.candidates);
+
     const homeOk = this.selectors.login.signedInIndicator
       ? await this.browser.isVisible(this.selectors.login.signedInIndicator).catch(() => false)
       : false;
@@ -343,7 +483,7 @@ export class DesignerController {
       throw new Error(`Not signed in to claude.ai/design, or on an unrecognized page${suffix}. Sign in in the CDP-attached Chrome.`);
     }
     upsertSession(this.key, { lastUrl: await this.currentUrl() });
-    return { ok: true, url: await this.currentUrl(), inSession: await this.isInSession() };
+    return { ok: true, url: await this.currentUrl(), inSession: await this.isInSession(), interstitials };
   }
 
   async createSession(
@@ -369,6 +509,11 @@ export class DesignerController {
     if (!name?.trim()) throw new Error('create requires a non-empty name (used as the project seed prompt).');
     await this.browser.open(DESIGN_HOME);
     await this.browser.waitLoad('networkidle').catch(() => null);
+    // createSession opens home directly (not via ensureReady), so run the same
+    // interstitial pre-flight — a Cloudflare check or transient error on home
+    // would otherwise stall waitFor(creator) with a misleading timeout.
+    const interstitials = await this.clearInterstitials();
+    if (interstitials.blocked) throw this._interstitialError(interstitials.blocked, 0);
     await this.browser.waitFor(this.selectors.home.creator);
 
     const fidelityHint =
@@ -1232,6 +1377,10 @@ export class DesignerController {
 
 function hashHex(s: string): string {
   return crypto.createHash('sha256').update(s).digest('hex').slice(0, 16);
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function extractFileParam(url: string): string | null {

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -22,6 +22,7 @@ import {
   type InterstitialProbe,
   type InterstitialReport
 } from './interstitials.ts';
+import { OPEN_FILES_PANEL_EXPR } from './file-panel.ts';
 
 export interface Selectors {
   login: { signedInIndicator: string | null };
@@ -991,23 +992,14 @@ export class DesignerController {
       await new Promise((r) => setTimeout(r, 1500));
     }
 
-    // Open the Design Files dialog to get the richer file/folder listing.
-    // Click the label directly: React attaches handlers via root delegation, so
-    // the old walk-up-for-non-null-.onclick exhausted to null and never fired —
-    // a latent no-op that left this scrape seeing only bare-page filenames. A
-    // click on the label bubbles to React's delegated handler. Kept identical to
-    // the session.fileListScrape health anchor's opener so the probe exercises
-    // the SAME path production uses (PR #77 Codex P2). Idempotent — if already
-    // open it may toggle; we accept the occasional toggle vs probing panel state.
-    await this.browser.evalValue<boolean>(
-      `(() => {
-        const spans = Array.from(document.querySelectorAll('span'));
-        const label = spans.find(s => s.children.length === 0 && (s.textContent || '').trim() === 'Design Files');
-        if (!label) return false;
-        label.click();
-        return true;
-      })()`
-    ).catch(() => null);
+    // Open the Design Files dialog to get the richer file/folder listing, via the
+    // shared idempotent opener (file-panel.ts) — the SAME expression the
+    // session.fileListScrape health anchor uses, so the probe can't pass while
+    // this silently no-ops. It clicks the label (React root delegation; the old
+    // walk-up-for-non-null-.onclick never fired) and is OPEN-ONLY so the before/
+    // after listFiles() calls in iterate() don't toggle it shut mid-run (PR #77
+    // Codex P2).
+    await this.browser.evalValue<boolean>(OPEN_FILES_PANEL_EXPR).catch(() => null);
     await new Promise((r) => setTimeout(r, 600));
 
     const result = await this.browser.evalValue<{ files: string[]; folders: string[]; designFilesLabelVisible: boolean }>(

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -239,6 +239,12 @@ export class DesignerController {
       return { ...r, status: await this.getStatus() };
     }
     if (action === 'clear') {
+      // clearInterstitials acts on the currently-bound CDP tab; in a multi-key
+      // workflow that may be a DIFFERENT project. Select THIS key's stored tab
+      // first (scoped, activate-only — no navigation, so it won't hijack another
+      // key's tab) so the clear targets the requested session (PR #77 Codex P2).
+      if (isCdpEnabled()) await ensureCdpUp();
+      await this.selectMatchingTab().catch(() => null);
       const r = await this.clearInterstitials();
       return { ...r, status: await this.getStatus() };
     }

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -372,15 +372,19 @@ export class DesignerController {
   // and each action re-probes to CONFIRM before counting it handled. Blocking
   // kinds (cloudflare, transient-error) that survive are reported `blocked`; the
   // token banner is non-blocking (the shell stays usable) so it never blocks a
-  // verb even if its button can't be clicked (review #3 / #6). ensureCdpUp first
-  // so the standalone `designer clear` fails loud on a dead Chrome instead of
-  // reporting a false recovery (review #5b).
+  // verb even if its button can't be clicked (review #3 / #6). In CDP mode,
+  // ensureCdpUp first so the standalone `designer clear` fails loud on a dead
+  // Chrome instead of a false recovery (review #5b) — but GATE it on isCdpEnabled
+  // so the documented DESIGNER_CDP='' opt-out (where ensureCdpUp throws by design)
+  // still works: the probe/click/reload run over agent-browser, not CDP, so the
+  // clear itself needs no CDP. Without this gate, the createSession pre-flight
+  // would break `create` in the opt-out flow (PR #77 Codex P2).
   async clearInterstitials({
     maxPasses = 4,
     cloudflareWaitMs = 25_000,
     pollMs = 1500
   }: { maxPasses?: number; cloudflareWaitMs?: number; pollMs?: number } = {}): Promise<InterstitialReport> {
-    await ensureCdpUp();
+    if (isCdpEnabled()) await ensureCdpUp();
     const handled: InterstitialKind[] = [];
     for (let pass = 0; pass < maxPasses; pass++) {
       const kind = await this._classifyNow();
@@ -830,6 +834,12 @@ export class DesignerController {
     const stored = getSession(this.key);
     if (!stored?.designUrl) throw new Error(`No active session for key=${this.key}. Call createSession first.`);
     await this.resumeSession();
+    // ensureReady's pre-flight cleared the home/current page, but this cold-start
+    // just navigated to the stored project — an interstitial on the PROJECT page
+    // itself (token banner, transient error, Cloudflare) would otherwise reach the
+    // verb that called us. Clear again on the resumed page (PR #77 Codex P2).
+    const interstitials = await this.clearInterstitials();
+    if (interstitials.blocked) throw this._interstitialError(interstitials.blocked, 1);
   }
 
   async iterate(

--- a/file-panel.ts
+++ b/file-panel.ts
@@ -14,9 +14,14 @@
 // read the bare page and corrupt newFiles/removedFiles (PR #77 Codex P2). So we
 // only click when we can tell the panel is closed:
 //   1. trigger exposes aria-expanded → obey it (open iff 'false', no-op if 'true')
-//   2. otherwise → only click when no file list is already visible (e.g. a
-//      single-file / standalone project whose list is collapsed); never click
-//      when a list is already showing, to avoid closing it.
+//   2. otherwise → click only when NO file-list row is visible at all (a
+//      collapsed / standalone project). ANY visible filename row is treated as
+//      "already showing" — including a single-file project's one row — so we
+//      never toggle an open panel shut (PR #77 Codex P2: a 1-row open panel was
+//      slipping past a >=2 threshold and being closed, making iterate() report
+//      the lone file as removed). This matches the pre-fix behavior for projects
+//      whose files are already visible (no completeness regression) while still
+//      opening a genuinely-collapsed list.
 // Returns true if the label was found (clicked or already-open), false otherwise.
 export const OPEN_FILES_PANEL_EXPR = `(() => {
   const spans = Array.from(document.querySelectorAll('span'));
@@ -30,14 +35,12 @@ export const OPEN_FILES_PANEL_EXPR = `(() => {
     t = t.parentElement;
   }
   const fileRe = /^[A-Za-z0-9 _.()\\-]+\\.(html|css|js|jsx|tsx|ts|md|json|svg)$/i;
-  let rows = 0;
   const w = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
   let n;
   while ((n = w.nextNode())) {
     const tx = (n.textContent || '').trim();
-    if (fileRe.test(tx) && tx.length < 80 && ++rows >= 2) break;
+    if (fileRe.test(tx) && tx.length < 80) return true; // a file row is showing — don't toggle it shut
   }
-  if (rows >= 2) return true;
   label.click();
   return true;
 })()`;

--- a/file-panel.ts
+++ b/file-panel.ts
@@ -1,0 +1,43 @@
+// Opener for claude.ai/design's "Design Files" panel, shared by BOTH the live
+// listFilesDetailed scrape (designer-controller) and the session.fileListScrape
+// health anchor (ui-anchors) — one source so the probe exercises the exact path
+// production runs. They diverged once and the probe went green while production
+// silently no-op'd (PR #77 Codex P2); a shared constant prevents a repeat.
+//
+// React attaches handlers via root delegation, so the trigger's element.onclick
+// is null — we click the label (the event bubbles to React's delegated handler)
+// rather than walking up for a non-null .onclick (which never fires).
+//
+// IDEMPOTENT (open-only): a blind label.click() TOGGLES an already-open panel
+// CLOSED. listFilesDetailed leaves the panel open and iterate() calls listFiles()
+// both before AND after a generation, so a toggle would make the second scrape
+// read the bare page and corrupt newFiles/removedFiles (PR #77 Codex P2). So we
+// only click when we can tell the panel is closed:
+//   1. trigger exposes aria-expanded → obey it (open iff 'false', no-op if 'true')
+//   2. otherwise → only click when no file list is already visible (e.g. a
+//      single-file / standalone project whose list is collapsed); never click
+//      when a list is already showing, to avoid closing it.
+// Returns true if the label was found (clicked or already-open), false otherwise.
+export const OPEN_FILES_PANEL_EXPR = `(() => {
+  const spans = Array.from(document.querySelectorAll('span'));
+  const label = spans.find((s) => s.children.length === 0 && (s.textContent || '').trim() === 'Design Files');
+  if (!label) return false;
+  let t = label;
+  for (let i = 0; i < 4 && t; i++) {
+    const ex = t.getAttribute && t.getAttribute('aria-expanded');
+    if (ex === 'true') return true;
+    if (ex === 'false') { label.click(); return true; }
+    t = t.parentElement;
+  }
+  const fileRe = /^[A-Za-z0-9 _.()\\-]+\\.(html|css|js|jsx|tsx|ts|md|json|svg)$/i;
+  let rows = 0;
+  const w = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  let n;
+  while ((n = w.nextNode())) {
+    const tx = (n.textContent || '').trim();
+    if (fileRe.test(tx) && tx.length < 80 && ++rows >= 2) break;
+  }
+  if (rows >= 2) return true;
+  label.click();
+  return true;
+})()`;

--- a/file-panel.ts
+++ b/file-panel.ts
@@ -4,25 +4,23 @@
 // production runs. They diverged once and the probe went green while production
 // silently no-op'd (PR #77 Codex P2); a shared constant prevents a repeat.
 //
-// React attaches handlers via root delegation, so the trigger's element.onclick
-// is null — we click the label (the event bubbles to React's delegated handler)
-// rather than walking up for a non-null .onclick (which never fires).
+// Open-state is decided ONLY from the trigger's aria-expanded — the one reliable
+// signal. Two tempting alternatives are dead ends Codex walked us through (PR #77):
+//   - a blind label.click() TOGGLES an already-open panel shut, and iterate()
+//     calls listFiles() before+after a generation, so the second scrape reads the
+//     bare page and corrupts newFiles/removedFiles;
+//   - counting filename-like body text to infer "already open" can't tell a real
+//     panel row from a filename mentioned in a chat turn (index.html), so it
+//     skips opening and scrapes incidental text.
+// So: if the trigger exposes aria-expanded, obey it (open iff 'false'). If it
+// does NOT, leave the panel as-is — never a blind toggle, never a body-text
+// guess; the scrape then reads whatever is already visible (the long-standing
+// behavior). React attaches handlers via root delegation, so element.onclick is
+// null on the trigger — we click the label (the event bubbles to the delegated
+// handler) rather than walking up for a non-null .onclick (which never fires).
 //
-// IDEMPOTENT (open-only): a blind label.click() TOGGLES an already-open panel
-// CLOSED. listFilesDetailed leaves the panel open and iterate() calls listFiles()
-// both before AND after a generation, so a toggle would make the second scrape
-// read the bare page and corrupt newFiles/removedFiles (PR #77 Codex P2). So we
-// only click when we can tell the panel is closed:
-//   1. trigger exposes aria-expanded → obey it (open iff 'false', no-op if 'true')
-//   2. otherwise → click only when NO file-list row is visible at all (a
-//      collapsed / standalone project). ANY visible filename row is treated as
-//      "already showing" — including a single-file project's one row — so we
-//      never toggle an open panel shut (PR #77 Codex P2: a 1-row open panel was
-//      slipping past a >=2 threshold and being closed, making iterate() report
-//      the lone file as removed). This matches the pre-fix behavior for projects
-//      whose files are already visible (no completeness regression) while still
-//      opening a genuinely-collapsed list.
-// Returns true if the label was found (clicked or already-open), false otherwise.
+// Returns true when the "Design Files" label is present (opened or already-open
+// or left-as-is), false when it isn't found.
 export const OPEN_FILES_PANEL_EXPR = `(() => {
   const spans = Array.from(document.querySelectorAll('span'));
   const label = spans.find((s) => s.children.length === 0 && (s.textContent || '').trim() === 'Design Files');
@@ -34,13 +32,5 @@ export const OPEN_FILES_PANEL_EXPR = `(() => {
     if (ex === 'false') { label.click(); return true; }
     t = t.parentElement;
   }
-  const fileRe = /^[A-Za-z0-9 _.()\\-]+\\.(html|css|js|jsx|tsx|ts|md|json|svg)$/i;
-  const w = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
-  let n;
-  while ((n = w.nextNode())) {
-    const tx = (n.textContent || '').trim();
-    if (fileRe.test(tx) && tx.length < 80) return true; // a file row is showing — don't toggle it shut
-  }
-  label.click();
   return true;
 })()`;

--- a/interstitials.ts
+++ b/interstitials.ts
@@ -1,0 +1,85 @@
+// Interstitial detection for claude.ai/design.
+//
+// The 2026-06 design UI interrupts the automated flow with transient overlays
+// that carry no stable data-testid or ARIA role — they can only be matched by
+// their visible content. Each verb runs a pre-flight (DesignerController.
+// clearInterstitials, wired through ensureReady) so automation doesn't silently
+// stall on a banner, misread a frozen view as "done", or call a transient error
+// a context ceiling. Captured live 2026-06-19 against Chrome 149.
+//
+// Detection lives here — pure and unit-tested — so the copy heuristics have one
+// source of truth; the DOM/CDP glue (probe + click/reload/wait) stays in the
+// controller. This mirrors preview-host.ts / run-state.ts: classify in a tested
+// module, act in the controller.
+
+export type InterstitialKind = 'token-banner' | 'transient-error' | 'cloudflare';
+
+export type InterstitialAction = 'click-continue' | 'reload' | 'await-human';
+
+export interface InterstitialProbe {
+  /** document.body.innerText (the caller may truncate it). */
+  bodyText: string;
+  /** Trimmed textContent of every <button> currently in the DOM. */
+  buttonTexts: string[];
+}
+
+export interface InterstitialReport {
+  /** True when the page carries no unresolved interstitial. */
+  ok: boolean;
+  /** Interstitials acted on, in the order they were cleared. */
+  handled: InterstitialKind[];
+  /** An interstitial still present after handling (e.g. an unsolved Cloudflare
+   *  challenge, or one whose action target vanished), or null when clear. */
+  blocked: InterstitialKind | null;
+}
+
+// Cloudflare bot-check / "verify you are human" takeover. The most blocking of
+// the three — it replaces the app shell and can't be auto-solved, only waited
+// out (it often self-clears) or handed to a human.
+export const CLOUDFLARE_RE =
+  /verify you are human|performing security verification|review the security of your connection|checking your browser before|needs to review the security/i;
+
+// Transient "Something went wrong" error page. Require a corroborating action
+// phrase so an unrelated inline "something went wrong" string elsewhere on the
+// page doesn't trip a needless reload.
+export const TRANSIENT_ERROR_RE = /something went wrong/i;
+export const TRANSIENT_ERROR_CORROBORANT_RE = /try again|back to projects/i;
+
+// Context-save nudge: "Start a new chat to save 483k tokens of context" with
+// New chat / Continue here. We click "Continue here" to keep the session's
+// context — "New chat" would discard it.
+export const TOKEN_BANNER_RE = /start a new chat to save\b|save \d+k tokens of context/i;
+export const CONTINUE_HERE_TEXT = 'Continue here';
+
+function hasContinueHere(buttonTexts: string[]): boolean {
+  const want = CONTINUE_HERE_TEXT.toLowerCase();
+  return buttonTexts.some((t) => (t || '').trim().toLowerCase() === want);
+}
+
+/**
+ * Classify the most pressing interstitial present, or null when the page is
+ * clear. Order is by severity: a Cloudflare takeover hides everything beneath
+ * it, so it's checked first; the token banner is the most benign (the composer
+ * stays usable beneath it) so it's checked last. The token banner additionally
+ * requires its "Continue here" button to be present — the phrase alone (e.g.
+ * echoed in chat history) is not enough to act on.
+ */
+export function classifyInterstitial(probe: InterstitialProbe): InterstitialKind | null {
+  const body = probe.bodyText || '';
+  if (CLOUDFLARE_RE.test(body)) return 'cloudflare';
+  if (TRANSIENT_ERROR_RE.test(body) && TRANSIENT_ERROR_CORROBORANT_RE.test(body)) return 'transient-error';
+  if (TOKEN_BANNER_RE.test(body) && hasContinueHere(probe.buttonTexts)) return 'token-banner';
+  return null;
+}
+
+/** The handling strategy for each interstitial kind. */
+export function plannedAction(kind: InterstitialKind): InterstitialAction {
+  switch (kind) {
+    case 'token-banner':
+      return 'click-continue';
+    case 'transient-error':
+      return 'reload';
+    case 'cloudflare':
+      return 'await-human';
+  }
+}

--- a/interstitials.ts
+++ b/interstitials.ts
@@ -1,6 +1,6 @@
 // Interstitial detection for claude.ai/design.
 //
-// The 2026-06 design UI interrupts the automated flow with transient overlays
+// The 2026-06 design UI interrupts the automated flow with content-only overlays
 // that carry no stable data-testid or ARIA role — they can only be matched by
 // their visible content. Each verb runs a pre-flight (DesignerController.
 // clearInterstitials, wired through ensureReady) so automation doesn't silently
@@ -11,6 +11,14 @@
 // source of truth; the DOM/CDP glue (probe + click/reload/wait) stays in the
 // controller. This mirrors preview-host.ts / run-state.ts: classify in a tested
 // module, act in the controller.
+//
+// STRUCTURAL GUARD (review #1): the two TAKEOVER kinds (cloudflare,
+// transient-error) replace the whole app shell, so they're classified ONLY when
+// the shell is gone — `appShellPresent === false`. Without this, a design session
+// whose chat transcript mentions "verify you are human" (an auth/CAPTCHA mockup)
+// or "something went wrong … try again" (a Claude apology) would be misread as a
+// real overlay and hard-block every verb. The token banner is benign (it sits
+// over a live shell) and is gated on its own action button instead.
 
 export type InterstitialKind = 'token-banner' | 'transient-error' | 'cloudflare';
 
@@ -21,17 +29,45 @@ export interface InterstitialProbe {
   bodyText: string;
   /** Trimmed textContent of every <button> currently in the DOM. */
   buttonTexts: string[];
+  /** True when the app shell (composer or chat-messages) is rendered. A real
+   *  Cloudflare / "Something went wrong" takeover removes it; the token banner
+   *  leaves it. Distinguishes a true overlay from transcript text mentioning
+   *  the same phrases. */
+  appShellPresent: boolean;
 }
 
 export interface InterstitialReport {
-  /** True when the page carries no unresolved interstitial. */
+  /** True when the page carries no unresolved BLOCKING interstitial. A residual
+   *  token banner (benign — shell stays usable) is still ok:true. */
   ok: boolean;
-  /** Interstitials acted on, in the order they were cleared. */
+  /** Interstitials confirmed cleared (re-probed), in order. */
   handled: InterstitialKind[];
-  /** An interstitial still present after handling (e.g. an unsolved Cloudflare
-   *  challenge, or one whose action target vanished), or null when clear. */
+  /** A BLOCKING interstitial still present after handling (unsolved Cloudflare,
+   *  or a transient error that survived reloads), or null. Never token-banner —
+   *  that's non-blocking. */
   blocked: InterstitialKind | null;
 }
+
+export interface ClassifyOpts {
+  /** Override the token-banner action-button text (selectors.interstitials.
+   *  continueHere). Threaded so detection and the click stay on ONE source of
+   *  truth — otherwise an operator override would let the click target drift
+   *  from what the classifier gates on (review #3b). */
+  continueHere?: string;
+}
+
+// A single DOM read producing the InterstitialProbe shape. Exported as the ONE
+// source so the live pre-flight (designer-controller) and the CI diagnostic
+// (ci-health) probe identically — including the appShellPresent guard (review
+// #5 / below-gate dedup). Evaluated via browser.evalValue.
+export const INTERSTITIAL_PROBE_EXPR = `(() => ({
+  bodyText: ((document.body && document.body.innerText) || '').slice(0, 20000),
+  buttonTexts: Array.from(document.querySelectorAll('button'))
+    .map((b) => (b.textContent || '').trim())
+    .filter(Boolean)
+    .slice(0, 300),
+  appShellPresent: !!document.querySelector('[data-testid="chat-composer-input"], [data-testid="chat-messages"]')
+}))()`;
 
 // Cloudflare bot-check / "verify you are human" takeover. The most blocking of
 // the three — it replaces the app shell and can't be auto-solved, only waited
@@ -39,11 +75,11 @@ export interface InterstitialReport {
 export const CLOUDFLARE_RE =
   /verify you are human|performing security verification|review the security of your connection|checking your browser before|needs to review the security/i;
 
-// Transient "Something went wrong" error page. Require a corroborating action
-// phrase so an unrelated inline "something went wrong" string elsewhere on the
-// page doesn't trip a needless reload.
+// Transient "Something went wrong" error page. Gated on app-shell-absence AND a
+// real action button (review #1) so an inline "something went wrong" string in
+// the transcript can't trip a reload storm.
 export const TRANSIENT_ERROR_RE = /something went wrong/i;
-export const TRANSIENT_ERROR_CORROBORANT_RE = /try again|back to projects/i;
+export const TRANSIENT_ERROR_BUTTON_RE = /^(try again|back to projects)$/i;
 
 // Context-save nudge: "Start a new chat to save 483k tokens of context" with
 // New chat / Continue here. We click "Continue here" to keep the session's
@@ -51,24 +87,31 @@ export const TRANSIENT_ERROR_CORROBORANT_RE = /try again|back to projects/i;
 export const TOKEN_BANNER_RE = /start a new chat to save\b|save \d+k tokens of context/i;
 export const CONTINUE_HERE_TEXT = 'Continue here';
 
-function hasContinueHere(buttonTexts: string[]): boolean {
-  const want = CONTINUE_HERE_TEXT.toLowerCase();
+function hasButtonText(buttonTexts: string[], text: string): boolean {
+  const want = text.trim().toLowerCase();
   return buttonTexts.some((t) => (t || '').trim().toLowerCase() === want);
+}
+
+function hasButtonMatching(buttonTexts: string[], re: RegExp): boolean {
+  return buttonTexts.some((t) => re.test((t || '').trim()));
 }
 
 /**
  * Classify the most pressing interstitial present, or null when the page is
  * clear. Order is by severity: a Cloudflare takeover hides everything beneath
  * it, so it's checked first; the token banner is the most benign (the composer
- * stays usable beneath it) so it's checked last. The token banner additionally
- * requires its "Continue here" button to be present — the phrase alone (e.g.
- * echoed in chat history) is not enough to act on.
+ * stays usable beneath it) so it's checked last. Takeover kinds require the app
+ * shell to be ABSENT (see module header); the token banner requires its action
+ * button to be present (the phrase alone — e.g. echoed in chat — is not enough).
  */
-export function classifyInterstitial(probe: InterstitialProbe): InterstitialKind | null {
+export function classifyInterstitial(probe: InterstitialProbe, opts: ClassifyOpts = {}): InterstitialKind | null {
   const body = probe.bodyText || '';
-  if (CLOUDFLARE_RE.test(body)) return 'cloudflare';
-  if (TRANSIENT_ERROR_RE.test(body) && TRANSIENT_ERROR_CORROBORANT_RE.test(body)) return 'transient-error';
-  if (TOKEN_BANNER_RE.test(body) && hasContinueHere(probe.buttonTexts)) return 'token-banner';
+  const buttons = probe.buttonTexts || [];
+  if (!probe.appShellPresent) {
+    if (CLOUDFLARE_RE.test(body)) return 'cloudflare';
+    if (TRANSIENT_ERROR_RE.test(body) && hasButtonMatching(buttons, TRANSIENT_ERROR_BUTTON_RE)) return 'transient-error';
+  }
+  if (TOKEN_BANNER_RE.test(body) && hasButtonText(buttons, opts.continueHere || CONTINUE_HERE_TEXT)) return 'token-banner';
   return null;
 }
 
@@ -82,4 +125,10 @@ export function plannedAction(kind: InterstitialKind): InterstitialAction {
     case 'cloudflare':
       return 'await-human';
   }
+}
+
+/** Blocking interstitials make a verb impossible; the token banner does not
+ *  (the shell stays usable beneath it), so a residual one is never fatal. */
+export function isBlockingInterstitial(kind: InterstitialKind): boolean {
+  return kind !== 'token-banner';
 }

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -29,10 +29,10 @@ server.registerTool(
   'designer_session',
   {
     description:
-      "Enter, inspect, or transition a claude.ai/design session. Default action='status' is a pure read — safe to call anytime to orient without side effects. Returns stored state + currentUrl + inSession + availableFiles so you can avoid a follow-up list call. Use this as the first tool in any agent loop.\n\nActions:\n- status (default): read-only, no mutations\n- ensure_ready: navigate to /design if not already there\n- resume: navigate into the stored designUrl for this key (fails if nothing stored)\n- create: new project (requires name)\n- adopt: bind the already-open /design/p/<uuid> tab to this key (name optional). Use this when create can't drive the redesigned creation-cards home — open the project by hand, then adopt it.",
+      "Enter, inspect, or transition a claude.ai/design session. Default action='status' is a pure read — safe to call anytime to orient without side effects. Returns stored state + currentUrl + inSession + availableFiles so you can avoid a follow-up list call. Use this as the first tool in any agent loop.\n\nActions:\n- status (default): read-only, no mutations\n- ensure_ready: navigate to /design if not already there\n- resume: navigate into the stored designUrl for this key (fails if nothing stored)\n- create: new project (requires name)\n- adopt: bind the already-open /design/p/<uuid> tab to this key (name optional). Use this when create can't drive the redesigned creation-cards home — open the project by hand, then adopt it.\n- clear: dismiss interstitial overlays (the 495k-token 'Continue here' banner, a transient 'Something went wrong' page, or a Cloudflare bot-check). Verbs run this automatically via ensure_ready; call it explicitly to recover a stuck session.",
     inputSchema: {
       key: z.string().optional().describe('Stable key for this loop (e.g., feature name). Defaults to "default".'),
-      action: z.enum(['status', 'ensure_ready', 'resume', 'create', 'adopt']).optional().describe('Default: status'),
+      action: z.enum(['status', 'ensure_ready', 'resume', 'create', 'adopt', 'clear']).optional().describe('Default: status'),
       name: z.string().optional().describe('Required when action=create; optional label when action=adopt.'),
       fidelity: z
         .enum(['wireframe', 'highfi'])

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cli": "tsx cli.ts",
     "setup": "tsx cli.ts setup",
     "doctor": "tsx cli.ts doctor",
-    "test": "npm run build && node --test tests/cli-metadata.test.mjs && node --import tsx --test tests/run-state.*.test.mjs tests/cdp-trace.*.test.mjs tests/ui-drift.*.test.mjs",
+    "test": "npm run build && node --test tests/cli-metadata.test.mjs && node --import tsx --test tests/run-state.*.test.mjs tests/cdp-trace.*.test.mjs tests/ui-drift.*.test.mjs tests/interstitials.*.test.mjs",
     "check": "tsc --noEmit",
     "build": "tsc -p tsconfig.build.json",
     "prepack": "npm run check && npm run build",

--- a/preview-host.ts
+++ b/preview-host.ts
@@ -33,6 +33,12 @@ export function previewIframeVariant(src: string): 'signed-token' | 'bootstrap-s
 // drift, that string does not. Used to assert the OOPIF read returned rendered
 // content, not the loader, and to defend callers against saving a shell as the
 // captured artifact. Empty / non-shell HTML → false (don't misread "no sample").
+//
+// Size-bounded (review below-gate): a rendered design that legitimately
+// DOCUMENTS the preview protocol could contain the marker string, so require the
+// document also be loader-sized. The real shell is ~1.1KB; any rendered design is
+// far larger, so the marker + a sub-4KB body is an unambiguous shell signal.
+const BOOTSTRAP_SHELL_MAX_BYTES = 4000;
 export function isBootstrapShellHtml(html: string): boolean {
-  return typeof html === 'string' && html.includes('omelette-preview-init');
+  return typeof html === 'string' && html.length < BOOTSTRAP_SHELL_MAX_BYTES && html.includes('omelette-preview-init');
 }

--- a/preview-host.ts
+++ b/preview-host.ts
@@ -24,3 +24,15 @@ export function previewIframeVariant(src: string): 'signed-token' | 'bootstrap-s
   if (/\/_bootstrap/.test(src)) return 'bootstrap-subdomain';
   return 'other';
 }
+
+// True when `html` is the unauthenticated ~1.1KB loader shell the bootstrap
+// iframe serves to the parent origin (not the rendered design). A node fetch of a
+// bootstrap-subdomain src always returns this shell; the real DOM only exists in
+// the cross-origin OOPIF (see oopif-reader.ts). The shell's stable signature is
+// its postMessage init handshake ('omelette-preview-init') — class/markup hashes
+// drift, that string does not. Used to assert the OOPIF read returned rendered
+// content, not the loader, and to defend callers against saving a shell as the
+// captured artifact. Empty / non-shell HTML → false (don't misread "no sample").
+export function isBootstrapShellHtml(html: string): boolean {
+  return typeof html === 'string' && html.includes('omelette-preview-init');
+}

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -13,6 +13,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { createBrowser, type Browser } from '../browser.ts';
 import { runHealth, type ProbeResult } from '../ui-anchors.ts';
 import { REPO_ROOT } from '../repo-root.ts';
+import { classifyInterstitial, type InterstitialKind } from '../interstitials.ts';
 
 const CDP_PORT = process.env.DESIGNER_CDP || '9222';
 const CHROME_PROFILE = path.join(os.homedir(), '.chrome-designer-profile');
@@ -234,6 +235,27 @@ async function maybeSnapshot(browser: Browser): Promise<{ url: string; htmlBytes
   }
 }
 
+// Which interstitial overlay (if any) is on the page Chrome ended on. Recorded
+// in every artifact so a wall of anchor failures isn't misattributed to selector
+// drift when the real cause was a transient overlay (token banner / "Something
+// went wrong" / Cloudflare bot-check) — the "misread" failure mode the live
+// pre-flight (designer clear) addresses for verbs. Diagnostic only: never fails
+// the run. Reuses the same classifier the pre-flight uses (interstitials.ts).
+async function probeInterstitial(browser: Browser): Promise<InterstitialKind | null> {
+  const probe = await browser
+    .evalValue<{ bodyText: string; buttonTexts: string[] }>(
+      `(() => ({
+        bodyText: ((document.body && document.body.innerText) || '').slice(0, 20000),
+        buttonTexts: Array.from(document.querySelectorAll('button'))
+          .map((b) => (b.textContent || '').trim())
+          .filter(Boolean)
+          .slice(0, 300)
+      }))()`
+    )
+    .catch(() => ({ bodyText: '', buttonTexts: [] }));
+  return classifyInterstitial(probe || { bodyText: '', buttonTexts: [] });
+}
+
 async function main(): Promise<void> {
   const startedAt = new Date().toISOString();
 
@@ -324,6 +346,9 @@ async function main(): Promise<void> {
   const url = (await browser.url().catch(() => '')) || '';
 
   const diag = fail ? await maybeSnapshot(browser) : null;
+  // Captured on whichever page Chrome ended on (session if probeUrl set, else
+  // home) — same final-state semantics as maybeSnapshot.
+  const interstitial = await probeInterstitial(browser);
 
   const payload = {
     ok: !fail,
@@ -346,6 +371,7 @@ async function main(): Promise<void> {
       counts,
       results
     },
+    interstitial,
     diagnostics: diag
   };
 

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -245,6 +245,12 @@ async function probeInterstitial(browser: Browser): Promise<InterstitialKind | n
   // Shared INTERSTITIAL_PROBE_EXPR keeps this diagnostic and the live pre-flight
   // (designer-controller) classifying identically — including the appShellPresent
   // guard, without which transcript text would false-classify here too.
+  //
+  // Note: unlike the controller's _classifyNow, this does NOT thread a
+  // selectors.override.json `continueHere` override, so an operator with a
+  // custom token-banner button label would see it recorded as null here. That's
+  // acceptable — this field is diagnostic-only (never fails the run), and CI runs
+  // the published selectors, not a local override (PR #77 Claude review).
   const probe = await browser.evalValue<InterstitialProbe>(INTERSTITIAL_PROBE_EXPR).catch(() => null);
   return probe ? classifyInterstitial(probe) : null;
 }

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -13,7 +13,7 @@ import { spawn, spawnSync } from 'node:child_process';
 import { createBrowser, type Browser } from '../browser.ts';
 import { runHealth, type ProbeResult } from '../ui-anchors.ts';
 import { REPO_ROOT } from '../repo-root.ts';
-import { classifyInterstitial, type InterstitialKind } from '../interstitials.ts';
+import { classifyInterstitial, INTERSTITIAL_PROBE_EXPR, type InterstitialKind, type InterstitialProbe } from '../interstitials.ts';
 
 const CDP_PORT = process.env.DESIGNER_CDP || '9222';
 const CHROME_PROFILE = path.join(os.homedir(), '.chrome-designer-profile');
@@ -242,18 +242,11 @@ async function maybeSnapshot(browser: Browser): Promise<{ url: string; htmlBytes
 // pre-flight (designer clear) addresses for verbs. Diagnostic only: never fails
 // the run. Reuses the same classifier the pre-flight uses (interstitials.ts).
 async function probeInterstitial(browser: Browser): Promise<InterstitialKind | null> {
-  const probe = await browser
-    .evalValue<{ bodyText: string; buttonTexts: string[] }>(
-      `(() => ({
-        bodyText: ((document.body && document.body.innerText) || '').slice(0, 20000),
-        buttonTexts: Array.from(document.querySelectorAll('button'))
-          .map((b) => (b.textContent || '').trim())
-          .filter(Boolean)
-          .slice(0, 300)
-      }))()`
-    )
-    .catch(() => ({ bodyText: '', buttonTexts: [] }));
-  return classifyInterstitial(probe || { bodyText: '', buttonTexts: [] });
+  // Shared INTERSTITIAL_PROBE_EXPR keeps this diagnostic and the live pre-flight
+  // (designer-controller) classifying identically — including the appShellPresent
+  // guard, without which transcript text would false-classify here too.
+  const probe = await browser.evalValue<InterstitialProbe>(INTERSTITIAL_PROBE_EXPR).catch(() => null);
+  return probe ? classifyInterstitial(probe) : null;
 }
 
 async function main(): Promise<void> {

--- a/selectors.json
+++ b/selectors.json
@@ -1,6 +1,6 @@
 {
   "_notes": "Captured 2026-04-17 from Chrome 147 via CDP. Override at ~/.designer/selectors.override.json. Prefer data-testid over class names — Claude's styled-components classes (sc-xxx) are regenerated on every build.",
-  "_drift": "2026-06 (issue #61): the home was rebuilt around a composer. Captured live 2026-06-16 from Chrome 149 (signed-in profile). There is no project-name input or wireframe/high-fi toggle anymore — you seed an intent in the chat composer ([data-testid=chat-composer-input], the SAME element as the in-session composer) and click 'Start project' ([data-testid=chat-send-button], the same as the in-session send button). Creation-type cards (Start anywhere / Slides / Prototype / Product wireframe / Doc / Animation / Blank canvas) are text-only buttons with no data-testid; the default flow doesn't require clicking one. Projects render as <a href=/design/p/<uuid>> with the name as text (no project-card/projects-list testid). `designer adopt` remains available to bind an already-open tab to a key.",
+  "_drift": "2026-06 (issue #61): the home was rebuilt around a composer. Captured live 2026-06-16 from Chrome 149 (signed-in profile); creation-type card labels re-captured 2026-06-19. There is no project-name input or wireframe/high-fi toggle anymore — you seed an intent in the chat composer ([data-testid=chat-composer-input], the SAME element as the in-session composer) and click 'Start project' ([data-testid=chat-send-button], the same as the in-session send button). Creation-type cards (Start with a file / Slides / Product prototype / Product wireframe / Document / Animation / Blank canvas) are text-only buttons with no data-testid; the default flow doesn't require clicking one, so wireframeButtonText/highFiButtonText are health-anchor drift sentinels only (NOT on the create path). The high-fi card was renamed 'Prototype' → 'Product prototype' (auto-heal PR #75/#76). Projects render as <a href=/design/p/<uuid>> with the name as text (no project-card/projects-list testid). `designer adopt` remains available to bind an already-open tab to a key.",
   "_urls": {
     "home": "https://claude.ai/design",
     "session": "https://claude.ai/design/p/{uuid}"
@@ -12,7 +12,7 @@
     "creator": "[data-testid=\"chat-composer-input\"]",
     "nameInput": "[data-testid=\"chat-composer-input\"]",
     "wireframeButtonText": "Product wireframe",
-    "highFiButtonText": "Prototype",
+    "highFiButtonText": "Product prototype",
     "createButton": "[data-testid=\"chat-send-button\"]",
     "projectsList": "a[href*=\"/design/p/\"]",
     "projectCard": "a[href*=\"/design/p/\"]"
@@ -33,5 +33,9 @@
   "messages": {
     "chatMessagesContainer": "[data-testid=\"chat-messages\"]",
     "generatingIndicator": null
+  },
+  "interstitials": {
+    "_note": "Content-only overlays on claude.ai/design (no data-testid). Detection regexes live in interstitials.ts (the unit-tested source of truth); this block only overrides the actionable button text. Captured live 2026-06-19 (Chrome 149). The token banner ('Start a new chat to save Nk tokens of context') is dismissed by clicking 'Continue here' — NOT 'New chat', which discards the session's context. Verbs run this pre-flight via ensureReady; recover manually with `designer clear`.",
+    "continueHere": "Continue here"
   }
 }

--- a/tests/interstitials.classify.test.mjs
+++ b/tests/interstitials.classify.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { classifyInterstitial, plannedAction, CONTINUE_HERE_TEXT } from '../interstitials.ts';
+
+// A normal in-session page (composer + chat) carries none of the interstitials.
+test('a clean session page classifies as no interstitial', () => {
+  assert.equal(
+    classifyInterstitial({
+      bodyText: 'Claude\nHere is your design. direction-dock.html 12 pages Tweaks Present Share Export',
+      buttonTexts: ['Send', 'Share', 'Export', 'Tweaks']
+    }),
+    null
+  );
+});
+
+test('the 495k-token banner classifies as token-banner when Continue here is present', () => {
+  assert.equal(
+    classifyInterstitial({
+      bodyText: 'Start a new chat to save 483k tokens of context',
+      buttonTexts: ['New chat', CONTINUE_HERE_TEXT, 'Send']
+    }),
+    'token-banner'
+  );
+});
+
+test('the token-banner phrase WITHOUT a Continue here button does not classify', () => {
+  // The phrase can echo in chat history; only an actionable button means act.
+  assert.equal(
+    classifyInterstitial({
+      bodyText: 'earlier I saw "Start a new chat to save 483k tokens of context" in the nudge',
+      buttonTexts: ['Send', 'Share']
+    }),
+    null
+  );
+});
+
+test('token-banner detection is case-insensitive and matches varied counts', () => {
+  for (const n of ['1k', '12k', '999k']) {
+    assert.equal(
+      classifyInterstitial({
+        bodyText: `START A NEW CHAT TO SAVE ${n} TOKENS OF CONTEXT`,
+        buttonTexts: ['Continue here']
+      }),
+      'token-banner'
+    );
+  }
+});
+
+test('"Something went wrong" needs a corroborating action phrase to classify', () => {
+  // Bare phrase (could appear inline anywhere) → no needless reload.
+  assert.equal(
+    classifyInterstitial({ bodyText: 'Something went wrong in the generated copy', buttonTexts: [] }),
+    null
+  );
+  // With "Try again" → transient-error.
+  assert.equal(
+    classifyInterstitial({
+      bodyText: 'Something went wrong\nPlease try again in a moment',
+      buttonTexts: ['Try again']
+    }),
+    'transient-error'
+  );
+  // With "Back to projects" → transient-error.
+  assert.equal(
+    classifyInterstitial({
+      bodyText: 'Something went wrong\nBack to projects',
+      buttonTexts: ['Back to projects']
+    }),
+    'transient-error'
+  );
+});
+
+test('the Cloudflare bot-check classifies as cloudflare', () => {
+  assert.equal(
+    classifyInterstitial({
+      bodyText: 'claude.ai\nVerify you are human by completing the action below.',
+      buttonTexts: []
+    }),
+    'cloudflare'
+  );
+  assert.equal(
+    classifyInterstitial({
+      bodyText: 'Performing security verification…',
+      buttonTexts: []
+    }),
+    'cloudflare'
+  );
+});
+
+test('Cloudflare wins over a co-present token banner (severity order)', () => {
+  assert.equal(
+    classifyInterstitial({
+      bodyText: 'Verify you are human\nStart a new chat to save 483k tokens of context',
+      buttonTexts: ['Continue here']
+    }),
+    'cloudflare'
+  );
+});
+
+test('plannedAction maps each kind to its handling strategy', () => {
+  assert.equal(plannedAction('token-banner'), 'click-continue');
+  assert.equal(plannedAction('transient-error'), 'reload');
+  assert.equal(plannedAction('cloudflare'), 'await-human');
+});
+
+test('empty / degraded probe is treated as clear', () => {
+  assert.equal(classifyInterstitial({ bodyText: '', buttonTexts: [] }), null);
+});

--- a/tests/interstitials.classify.test.mjs
+++ b/tests/interstitials.classify.test.mjs
@@ -1,24 +1,33 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { classifyInterstitial, plannedAction, CONTINUE_HERE_TEXT } from '../interstitials.ts';
+import { classifyInterstitial, plannedAction, isBlockingInterstitial, CONTINUE_HERE_TEXT } from '../interstitials.ts';
 
-// A normal in-session page (composer + chat) carries none of the interstitials.
+// Probe builder — defaults to a healthy session (app shell present) so each test
+// states only what it varies. Takeover kinds require appShellPresent:false.
+function probe({ bodyText = '', buttonTexts = [], appShellPresent = true } = {}) {
+  return { bodyText, buttonTexts, appShellPresent };
+}
+
 test('a clean session page classifies as no interstitial', () => {
   assert.equal(
-    classifyInterstitial({
-      bodyText: 'Claude\nHere is your design. direction-dock.html 12 pages Tweaks Present Share Export',
-      buttonTexts: ['Send', 'Share', 'Export', 'Tweaks']
-    }),
+    classifyInterstitial(
+      probe({
+        bodyText: 'Claude\nHere is your design. direction-dock.html 12 pages Tweaks Present Share Export',
+        buttonTexts: ['Send', 'Share', 'Export', 'Tweaks']
+      })
+    ),
     null
   );
 });
 
 test('the 495k-token banner classifies as token-banner when Continue here is present', () => {
   assert.equal(
-    classifyInterstitial({
-      bodyText: 'Start a new chat to save 483k tokens of context',
-      buttonTexts: ['New chat', CONTINUE_HERE_TEXT, 'Send']
-    }),
+    classifyInterstitial(
+      probe({
+        bodyText: 'Start a new chat to save 483k tokens of context',
+        buttonTexts: ['New chat', CONTINUE_HERE_TEXT, 'Send']
+      })
+    ),
     'token-banner'
   );
 });
@@ -26,10 +35,12 @@ test('the 495k-token banner classifies as token-banner when Continue here is pre
 test('the token-banner phrase WITHOUT a Continue here button does not classify', () => {
   // The phrase can echo in chat history; only an actionable button means act.
   assert.equal(
-    classifyInterstitial({
-      bodyText: 'earlier I saw "Start a new chat to save 483k tokens of context" in the nudge',
-      buttonTexts: ['Send', 'Share']
-    }),
+    classifyInterstitial(
+      probe({
+        bodyText: 'earlier I saw "Start a new chat to save 483k tokens of context" in the nudge',
+        buttonTexts: ['Send', 'Share']
+      })
+    ),
     null
   );
 });
@@ -37,64 +48,84 @@ test('the token-banner phrase WITHOUT a Continue here button does not classify',
 test('token-banner detection is case-insensitive and matches varied counts', () => {
   for (const n of ['1k', '12k', '999k']) {
     assert.equal(
-      classifyInterstitial({
-        bodyText: `START A NEW CHAT TO SAVE ${n} TOKENS OF CONTEXT`,
-        buttonTexts: ['Continue here']
-      }),
+      classifyInterstitial(probe({ bodyText: `START A NEW CHAT TO SAVE ${n} TOKENS OF CONTEXT`, buttonTexts: ['Continue here'] })),
       'token-banner'
     );
   }
 });
 
-test('"Something went wrong" needs a corroborating action phrase to classify', () => {
-  // Bare phrase (could appear inline anywhere) → no needless reload.
+// --- Structural guard (review #1): takeover kinds require app-shell-absent -----
+
+test('transcript text that MENTIONS a takeover is NOT classified while the shell is up', () => {
+  // A user designing an auth/CAPTCHA screen; Claude's reply is in body.innerText.
   assert.equal(
-    classifyInterstitial({ bodyText: 'Something went wrong in the generated copy', buttonTexts: [] }),
-    null
+    classifyInterstitial(
+      probe({
+        bodyText: 'Claude\nFor the CAPTCHA screen add a "Verify you are human" heading and a checkbox.',
+        buttonTexts: ['Send', 'Share'],
+        appShellPresent: true
+      })
+    ),
+    null,
+    'cloudflare phrase in transcript must not block a healthy session'
   );
-  // With "Try again" → transient-error.
+  // A Claude apology in the transcript with a "Try again" affordance.
   assert.equal(
-    classifyInterstitial({
-      bodyText: 'Something went wrong\nPlease try again in a moment',
-      buttonTexts: ['Try again']
-    }),
-    'transient-error'
-  );
-  // With "Back to projects" → transient-error.
-  assert.equal(
-    classifyInterstitial({
-      bodyText: 'Something went wrong\nBack to projects',
-      buttonTexts: ['Back to projects']
-    }),
-    'transient-error'
+    classifyInterstitial(
+      probe({
+        bodyText: 'Claude\nSomething went wrong on my end — let me try again.',
+        buttonTexts: ['Try again', 'Send'],
+        appShellPresent: true
+      })
+    ),
+    null,
+    'transient-error phrase in transcript must not trigger a reload storm'
   );
 });
 
-test('the Cloudflare bot-check classifies as cloudflare', () => {
+test('a real Cloudflare takeover (shell gone) classifies as cloudflare', () => {
   assert.equal(
-    classifyInterstitial({
-      bodyText: 'claude.ai\nVerify you are human by completing the action below.',
-      buttonTexts: []
-    }),
+    classifyInterstitial(probe({ bodyText: 'claude.ai\nVerify you are human by completing the action below.', appShellPresent: false })),
     'cloudflare'
   );
+  assert.equal(classifyInterstitial(probe({ bodyText: 'Performing security verification…', appShellPresent: false })), 'cloudflare');
+});
+
+test('transient-error requires shell-absent AND a real action button', () => {
+  // Shell gone + phrase + button → transient-error.
   assert.equal(
-    classifyInterstitial({
-      bodyText: 'Performing security verification…',
-      buttonTexts: []
-    }),
-    'cloudflare'
+    classifyInterstitial(probe({ bodyText: 'Something went wrong', buttonTexts: ['Try again'], appShellPresent: false })),
+    'transient-error'
   );
+  assert.equal(
+    classifyInterstitial(probe({ bodyText: 'Something went wrong', buttonTexts: ['Back to projects'], appShellPresent: false })),
+    'transient-error'
+  );
+  // Shell gone + phrase but NO action button → not classified (avoid blind reload).
+  assert.equal(classifyInterstitial(probe({ bodyText: 'Something went wrong', buttonTexts: [], appShellPresent: false })), null);
 });
 
 test('Cloudflare wins over a co-present token banner (severity order)', () => {
   assert.equal(
-    classifyInterstitial({
-      bodyText: 'Verify you are human\nStart a new chat to save 483k tokens of context',
-      buttonTexts: ['Continue here']
-    }),
+    classifyInterstitial(
+      probe({
+        bodyText: 'Verify you are human\nStart a new chat to save 483k tokens of context',
+        buttonTexts: ['Continue here'],
+        appShellPresent: false
+      })
+    ),
     'cloudflare'
   );
+});
+
+// --- Override threading (review #3b): detection honors selectors override ------
+
+test('a configured continueHere override is honored by the classifier', () => {
+  const p = probe({ bodyText: 'Start a new chat to save 200k tokens of context', buttonTexts: ['Weiter hier', 'Neuer Chat'] });
+  // Default text would miss the renamed button → null.
+  assert.equal(classifyInterstitial(p), null);
+  // With the override, the same page classifies as token-banner.
+  assert.equal(classifyInterstitial(p, { continueHere: 'Weiter hier' }), 'token-banner');
 });
 
 test('plannedAction maps each kind to its handling strategy', () => {
@@ -103,6 +134,12 @@ test('plannedAction maps each kind to its handling strategy', () => {
   assert.equal(plannedAction('cloudflare'), 'await-human');
 });
 
+test('isBlockingInterstitial: token-banner is benign, takeovers block', () => {
+  assert.equal(isBlockingInterstitial('token-banner'), false);
+  assert.equal(isBlockingInterstitial('transient-error'), true);
+  assert.equal(isBlockingInterstitial('cloudflare'), true);
+});
+
 test('empty / degraded probe is treated as clear', () => {
-  assert.equal(classifyInterstitial({ bodyText: '', buttonTexts: [] }), null);
+  assert.equal(classifyInterstitial(probe({})), null);
 });

--- a/tests/ui-drift.matchers.test.mjs
+++ b/tests/ui-drift.matchers.test.mjs
@@ -55,6 +55,13 @@ test('isBootstrapShellHtml treats rendered HTML and empty/no-sample as not-a-she
   assert.equal(isBootstrapShellHtml(/** @type {any} */ (null)), false);
 });
 
+test('isBootstrapShellHtml is size-bounded — a large design documenting the protocol is not a shell', () => {
+  // A rendered design that legitimately mentions the marker (e.g. a doc explaining
+  // omelette-preview-init) but is far larger than the ~1.1KB loader → not a shell.
+  const bigDesign = '<!doctype html><html><body>' + 'x'.repeat(5000) + 'omelette-preview-init</body></html>';
+  assert.equal(isBootstrapShellHtml(bigDesign), false);
+});
+
 test('SESSION_URL_RE matches a /design/p/<uuid> tab and captures the project id', () => {
   const url = 'https://claude.ai/design/p/72e73856-7b63-4aed-b95a-caca5e3c0e05?file=index.html';
   const m = url.match(SESSION_URL_RE);

--- a/tests/ui-drift.matchers.test.mjs
+++ b/tests/ui-drift.matchers.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { isPreviewIframeSrc, previewIframeVariant } from '../preview-host.ts';
+import { isPreviewIframeSrc, previewIframeVariant, isBootstrapShellHtml } from '../preview-host.ts';
 import { SESSION_URL_RE } from '../designer-controller.ts';
 
 // Regression coverage for the 2026-06 claude.ai/design entry-layer drift
@@ -38,6 +38,21 @@ test('previewIframeVariant labels which addressing scheme matched', () => {
   assert.equal(previewIframeVariant(SIGNED), 'signed-token');
   assert.equal(previewIframeVariant(BOOTSTRAP), 'bootstrap-subdomain');
   assert.equal(previewIframeVariant('https://sub.claudeusercontent.com/foo.html'), 'other');
+});
+
+// The OOPIF read probe (session.oopifPreviewRead) fails when the capture returns
+// the loader shell instead of rendered HTML; isBootstrapShellHtml is that check.
+test('isBootstrapShellHtml detects the loader shell by its postMessage init signature', () => {
+  const shell =
+    '<!doctype html><meta charset=utf-8><title>.</title><script>(function(){var ALLOWED=["https://claude.ai"];window.addEventListener("message",function(e){if(e.data&&e.data.type==="omelette-preview-init"){}});})()</script>';
+  assert.equal(isBootstrapShellHtml(shell), true);
+});
+
+test('isBootstrapShellHtml treats rendered HTML and empty/no-sample as not-a-shell', () => {
+  assert.equal(isBootstrapShellHtml('<!doctype html><html><body><h1>Casefile Overview</h1></body></html>'), false);
+  assert.equal(isBootstrapShellHtml(''), false); // "no sample" must not read as a shell
+  // Defensive on non-string input (reader returns null → caller handles separately).
+  assert.equal(isBootstrapShellHtml(/** @type {any} */ (null)), false);
 });
 
 test('SESSION_URL_RE matches a /design/p/<uuid> tab and captures the project id', () => {

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -52,7 +52,7 @@ async function hasButtonMatching(browser: Browser, pattern: RegExp): Promise<boo
 // The design-preview iframe's src. Shared by the preview anchors below
 // (iframeSrcPattern / previewBootstrap / oopifPreviewRead) so they read the
 // element the same way. '' when absent (caller decides skip vs fail).
-async function previewIframeSrc(browser: Browser): Promise<string> {
+async function getPreviewIframeSrc(browser: Browser): Promise<string> {
   return (
     (await browser
       .evalValue<string>(
@@ -350,7 +350,7 @@ export const UI_ANCHORS: AnchorDef[] = [
     requires: 'session',
     check: async (b, url) => {
       if (!/[?&]file=/.test(url)) return { ok: true, detail: '(no file open — iframe not expected)' };
-      const src = await previewIframeSrc(b);
+      const src = await getPreviewIframeSrc(b);
       if (!src) return { ok: false, detail: 'file param present but iframe missing src' };
       const ok = isPreviewIframeSrc(src);
       return { ok, detail: ok ? `variant=${previewIframeVariant(src)}` : `src=${src.slice(0, 120)}...` };
@@ -372,7 +372,7 @@ export const UI_ANCHORS: AnchorDef[] = [
     requires: 'session',
     check: async (b, url) => {
       if (!/[?&]file=/.test(url)) return { ok: true, detail: '(no file open — preview regime not checked)' };
-      const src = await previewIframeSrc(b);
+      const src = await getPreviewIframeSrc(b);
       if (!src) return { ok: false, detail: 'file param present but iframe missing src' };
       if (!isPreviewIframeSrc(src)) return { ok: false, detail: `preview left claudeusercontent.com: ${src.slice(0, 120)}` };
       const variant = previewIframeVariant(src);
@@ -402,7 +402,7 @@ export const UI_ANCHORS: AnchorDef[] = [
     requires: 'session',
     check: async (_b, url) => {
       if (!/[?&]file=/.test(url)) return { ok: true, status: 'skip', detail: 'no file open — preview not expected' };
-      const src = await previewIframeSrc(_b);
+      const src = await getPreviewIframeSrc(_b);
       if (!src || !isPreviewIframeSrc(src)) return { ok: true, status: 'skip', detail: 'iframe not on a preview host' };
       const variant = previewIframeVariant(src);
       if (variant !== 'bootstrap-subdomain')

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -409,8 +409,15 @@ export const UI_ANCHORS: AnchorDef[] = [
         return { ok: true, status: 'skip', detail: `variant=${variant} — node-fetch path, OOPIF read not used` };
       if (!isCdpEnabled()) return { ok: true, status: 'skip', detail: "CDP disabled (DESIGNER_CDP=''); OOPIF read not probed" };
 
+      // By here CDP is enabled AND the preview is on the bootstrap-subdomain
+      // (OOPIF) path — so an attach failure is NOT inconclusive. Production
+      // fetchServedHtml uses the same reader and falls back to EMPTY html on
+      // attach failure, so snapshot/fetch/iterate would silently get no content.
+      // Fail the probe (don't skip) — this is the exact regression it exists to
+      // catch (PR #77 Codex P2).
       const reader = await OopifHtmlReader.attach({ preferUrlPrefix: url || null }).catch(() => null);
-      if (!reader) return { ok: true, status: 'skip', detail: 'OOPIF reader attach failed (CDP unavailable)' };
+      if (!reader)
+        return { ok: false, detail: 'OOPIF reader attach failed while CDP is enabled on the bootstrap-subdomain path — snapshot/fetch/iterate would get empty HTML' };
       try {
         const html = await reader.readPreviewHtml().catch(() => null);
         if (!html)

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -583,19 +583,22 @@ export const UI_ANCHORS: AnchorDef[] = [
           )
           .catch(() => false);
 
-      // The file-list panel renders a few seconds after navigation; scraping
-      // immediately races it — the recurring false "0 filenames" the daily probe
-      // filed (#64/#65/#68), even though `designer files` and a live scrape find
-      // the files once the panel is up. Retry with a bounded settle before
-      // concluding a regression.
+      // Open the panel ONCE up front. Clicking it on every retry would toggle an
+      // already-open panel closed mid-settle (oscillation — review below-gate);
+      // the panel header renders immediately, its file rows a beat later, so one
+      // click + the retry-scrape settle covers the late render. The file-list
+      // panel renders a few seconds after navigation; scraping immediately races
+      // it — the recurring false "0 filenames" the daily probe filed
+      // (#64/#65/#68), even though `designer files` and a live scrape find the
+      // files once the panel is up. Retry with a bounded settle before concluding
+      // a regression.
+      await openFilesPanel();
       let files: string[] = [];
       for (let attempt = 0; attempt < 6; attempt++) {
-        await openFilesPanel();
-        await sleep(300);
+        await sleep(attempt === 0 ? 300 : 700);
         const result = await scrape();
         files = Array.isArray(result.files) ? result.files : [];
         if (files.length > 0) break;
-        if (attempt < 5) await sleep(700);
       }
       if (files.length === 0) {
         // With no file open the file-list panel may legitimately be absent — don't

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -211,9 +211,11 @@ export const UI_ANCHORS: AnchorDef[] = [
   {
     id: 'home.highFiButton',
     category: 'home',
-    description: 'Prototype creation-type card',
+    // Renamed 'Prototype' → 'Product prototype' in the 2026-06-19 home build
+    // (auto-heal PR #75/#76). Off the create path — a drift sentinel only.
+    description: 'Product prototype creation-type card',
     requires: 'home',
-    check: async (b) => ({ ok: await hasButtonMatching(b, /^Prototype/) })
+    check: async (b) => ({ ok: await hasButtonMatching(b, /^Product prototype/) })
   },
   {
     id: 'home.createButton',
@@ -516,6 +518,27 @@ export const UI_ANCHORS: AnchorDef[] = [
           )
           .catch(() => ({ files: [] as string[] }));
 
+      // Production listFilesDetailed OPENS the "Design Files" panel before
+      // scraping; this anchor used to scrape the bare page, so on a project whose
+      // panel wasn't already rendered (e.g. a single-file standalone — PR #75/#76
+      // hit "Signup Wireframes (standalone)") it found 0 and false-failed while
+      // `designer files` worked. Open the panel first so the anchor exercises the
+      // same path. Idempotent + best-effort (matches listFilesDetailed).
+      const openFilesPanel = (): Promise<boolean> =>
+        b
+          .evalValue<boolean>(
+            `(() => {
+            const spans = Array.from(document.querySelectorAll('span'));
+            const label = spans.find((s) => s.children.length === 0 && (s.textContent || '').trim() === 'Design Files');
+            if (!label) return false;
+            let row = label;
+            while (row && row.onclick === null) row = row.parentElement;
+            if (row) row.click();
+            return true;
+          })()`
+          )
+          .catch(() => false);
+
       // The file-list panel renders a few seconds after navigation; scraping
       // immediately races it — the recurring false "0 filenames" the daily probe
       // filed (#64/#65/#68), even though `designer files` and a live scrape find
@@ -523,10 +546,12 @@ export const UI_ANCHORS: AnchorDef[] = [
       // concluding a regression.
       let files: string[] = [];
       for (let attempt = 0; attempt < 6; attempt++) {
+        await openFilesPanel();
+        await sleep(300);
         const result = await scrape();
         files = Array.isArray(result.files) ? result.files : [];
         if (files.length > 0) break;
-        if (attempt < 5) await sleep(1000);
+        if (attempt < 5) await sleep(700);
       }
       if (files.length === 0) {
         // With no file open the file-list panel may legitimately be absent — don't
@@ -537,6 +562,13 @@ export const UI_ANCHORS: AnchorDef[] = [
         }
         return { ok: false, detail: 'found 0 filenames after ~5s settle — scraper regex or DOM layout regressed' };
       }
+      // The anchor's invariant is "the scraper still detects filenames" — ≥1
+      // filename means the regex + DOM walk work. Whether the URL's ?file=
+      // appears among them is NOT a reliable sub-assertion: the panel lists the
+      // authoritative project files, and the active ?file= can legitimately be
+      // absent from it (a stale/virtual URL file — observed live: ?file=
+      // direction-dock.html while the panel lists casefile-*.html). So treat an
+      // active-file mismatch as informational, not a failure.
       const match = url.match(/[?&]file=([^&]+)/);
       if (match && match[1]) {
         // Claude Design's URL bar form-encodes spaces as '+'. decodeURIComponent
@@ -545,8 +577,8 @@ export const UI_ANCHORS: AnchorDef[] = [
         const activeFile = decodeURIComponent(match[1].replace(/\+/g, ' '));
         if (!files.includes(activeFile)) {
           return {
-            ok: false,
-            detail: `active file "${activeFile}" not in scrape ([${files.slice(0, 3).join(', ')}...]) — scraper missing files`
+            ok: true,
+            detail: `${files.length} file(s) detected; active "${activeFile}" not among them (URL file may be stale/virtual)`
           };
         }
       }

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -1,7 +1,8 @@
 import type { Browser } from './browser.ts';
 import { RunStateObserver } from './run-state.ts';
-import { isPreviewIframeSrc, previewIframeVariant } from './preview-host.ts';
+import { isPreviewIframeSrc, previewIframeVariant, isBootstrapShellHtml } from './preview-host.ts';
 import { isCdpEnabled } from './cdp-env.ts';
+import { OopifHtmlReader } from './oopif-reader.ts';
 
 // Every UI anchor this MCP depends on to work. Grouped by the surface state
 // they live on. A regression in Claude Design's UI will trip one or more of
@@ -46,6 +47,19 @@ async function hasButtonMatching(browser: Browser, pattern: RegExp): Promise<boo
       `(() => { const re = new RegExp(${JSON.stringify(pattern.source)}, ${JSON.stringify(pattern.flags)}); return Array.from(document.querySelectorAll('button')).some(b => re.test((b.textContent || '').trim())); })()`
     )
     .catch(() => false));
+}
+
+// The design-preview iframe's src. Shared by the preview anchors below
+// (iframeSrcPattern / previewBootstrap / oopifPreviewRead) so they read the
+// element the same way. '' when absent (caller decides skip vs fail).
+async function previewIframeSrc(browser: Browser): Promise<string> {
+  return (
+    (await browser
+      .evalValue<string>(
+        `(() => { const el = document.querySelector('[data-testid="html-viewer-iframe"]'); return (el && el.src) || ''; })()`
+      )
+      .catch(() => '')) || ''
+  );
 }
 
 function sleep(ms: number): Promise<void> {
@@ -336,9 +350,7 @@ export const UI_ANCHORS: AnchorDef[] = [
     requires: 'session',
     check: async (b, url) => {
       if (!/[?&]file=/.test(url)) return { ok: true, detail: '(no file open — iframe not expected)' };
-      const src = await b.evalValue<string>(
-        `(() => { const el = document.querySelector('[data-testid="html-viewer-iframe"]'); return (el && el.src) || ''; })()`
-      ).catch(() => '');
+      const src = await previewIframeSrc(b);
       if (!src) return { ok: false, detail: 'file param present but iframe missing src' };
       const ok = isPreviewIframeSrc(src);
       return { ok, detail: ok ? `variant=${previewIframeVariant(src)}` : `src=${src.slice(0, 120)}...` };
@@ -351,20 +363,16 @@ export const UI_ANCHORS: AnchorDef[] = [
     // rendered DOM over CDP. This anchor records which regime the live preview
     // is in so a swing back to signed-token (or to an unrecognized 'other'
     // shape) — which would silently route capture down the wrong path — is
-    // visible in the daily health probe. It does not attach CDP (that needs a
-    // live signed-in session); the capture itself is covered by the turn-RPC
-    // canary + the unit tests.
+    // visible in the daily health probe. This anchor records the regime only;
+    // the sibling `session.oopifPreviewRead` below actually attaches CDP and
+    // verifies the bootstrap-subdomain capture returns rendered HTML.
     id: 'network.previewBootstrap',
     category: 'pattern',
     description: 'preview iframe regime (bootstrap-subdomain => OOPIF CDP capture; signed-token => node fetch)',
     requires: 'session',
     check: async (b, url) => {
       if (!/[?&]file=/.test(url)) return { ok: true, detail: '(no file open — preview regime not checked)' };
-      const src = await b
-        .evalValue<string>(
-          `(() => { const el = document.querySelector('[data-testid="html-viewer-iframe"]'); return (el && el.src) || ''; })()`
-        )
-        .catch(() => '');
+      const src = await previewIframeSrc(b);
       if (!src) return { ok: false, detail: 'file param present but iframe missing src' };
       if (!isPreviewIframeSrc(src)) return { ok: false, detail: `preview left claudeusercontent.com: ${src.slice(0, 120)}` };
       const variant = previewIframeVariant(src);
@@ -377,6 +385,42 @@ export const UI_ANCHORS: AnchorDef[] = [
               ? 'variant=signed-token (legacy node-fetch path)'
               : `variant=other — unrecognized preview src shape (${src.slice(0, 120)}); capture path may be wrong`
       };
+    }
+  },
+  {
+    // End-to-end check of the OOPIF capture itself. iframeSrcPattern /
+    // previewBootstrap only inspect the src STRING — the CDP auto-attach read
+    // could silently return the ~1.1KB loader shell (or null) while both pass,
+    // handing snapshot/fetch/iterate empty HTML (inbox finding #3). This anchor
+    // attaches its own OopifHtmlReader (like checkTurnRpcContract attaches a
+    // RunStateObserver) and asserts the read returns rendered HTML, not the
+    // shell. Only the bootstrap-subdomain regime uses the OOPIF path; the
+    // signed-token / 'other' regimes use a node fetch, so they skip here.
+    id: 'session.oopifPreviewRead',
+    category: 'pattern',
+    description: 'OOPIF CDP read returns rendered preview HTML (not the bootstrap loader shell)',
+    requires: 'session',
+    check: async (_b, url) => {
+      if (!/[?&]file=/.test(url)) return { ok: true, status: 'skip', detail: 'no file open — preview not expected' };
+      const src = await previewIframeSrc(_b);
+      if (!src || !isPreviewIframeSrc(src)) return { ok: true, status: 'skip', detail: 'iframe not on a preview host' };
+      const variant = previewIframeVariant(src);
+      if (variant !== 'bootstrap-subdomain')
+        return { ok: true, status: 'skip', detail: `variant=${variant} — node-fetch path, OOPIF read not used` };
+      if (!isCdpEnabled()) return { ok: true, status: 'skip', detail: "CDP disabled (DESIGNER_CDP=''); OOPIF read not probed" };
+
+      const reader = await OopifHtmlReader.attach({ preferUrlPrefix: url || null }).catch(() => null);
+      if (!reader) return { ok: true, status: 'skip', detail: 'OOPIF reader attach failed (CDP unavailable)' };
+      try {
+        const html = await reader.readPreviewHtml().catch(() => null);
+        if (!html)
+          return { ok: false, detail: 'OOPIF read returned null — CDP capture path broken (snapshot/fetch/iterate would get empty HTML)' };
+        if (isBootstrapShellHtml(html))
+          return { ok: false, detail: `OOPIF read returned the bootstrap loader shell (${html.length}B), not rendered HTML` };
+        return { ok: true, detail: `read ${html.length}B of rendered HTML via OOPIF CDP capture` };
+      } finally {
+        reader.close();
+      }
     }
   },
   {

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -401,9 +401,17 @@ export const UI_ANCHORS: AnchorDef[] = [
     description: 'OOPIF CDP read returns rendered preview HTML (not the bootstrap loader shell)',
     requires: 'session',
     check: async (b, url) => {
-      if (!/[?&]file=/.test(url)) return { ok: true, status: 'skip', detail: 'no file open — preview not expected' };
-      const src = await getPreviewIframeSrc(b);
-      if (!src || !isPreviewIframeSrc(src)) return { ok: true, status: 'skip', detail: 'iframe not on a preview host' };
+      // Gate on a RENDERED preview iframe, not on ?file= in the URL: the daily-
+      // health canary (DESIGNER_PROBE_PROJECT_URL) is a BARE project URL, and
+      // claude.ai auto-opens a default file + renders its preview there — so a
+      // ?file= gate would skip the OOPIF check in exactly the CI run it exists to
+      // protect (PR #77 Codex P2). Wait briefly for the iframe to paint after nav.
+      let src = await getPreviewIframeSrc(b);
+      for (let i = 0; i < 6 && !isPreviewIframeSrc(src); i++) {
+        await sleep(500);
+        src = await getPreviewIframeSrc(b);
+      }
+      if (!isPreviewIframeSrc(src)) return { ok: true, status: 'skip', detail: 'no preview iframe rendered (no file open)' };
       const variant = previewIframeVariant(src);
       if (variant !== 'bootstrap-subdomain')
         return { ok: true, status: 'skip', detail: `variant=${variant} — node-fetch path, OOPIF read not used` };

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -400,9 +400,9 @@ export const UI_ANCHORS: AnchorDef[] = [
     category: 'pattern',
     description: 'OOPIF CDP read returns rendered preview HTML (not the bootstrap loader shell)',
     requires: 'session',
-    check: async (_b, url) => {
+    check: async (b, url) => {
       if (!/[?&]file=/.test(url)) return { ok: true, status: 'skip', detail: 'no file open — preview not expected' };
-      const src = await getPreviewIframeSrc(_b);
+      const src = await getPreviewIframeSrc(b);
       if (!src || !isPreviewIframeSrc(src)) return { ok: true, status: 'skip', detail: 'iframe not on a preview host' };
       const variant = previewIframeVariant(src);
       if (variant !== 'bootstrap-subdomain')
@@ -582,9 +582,12 @@ export const UI_ANCHORS: AnchorDef[] = [
             const spans = Array.from(document.querySelectorAll('span'));
             const label = spans.find((s) => s.children.length === 0 && (s.textContent || '').trim() === 'Design Files');
             if (!label) return false;
-            let row = label;
-            while (row && row.onclick === null) row = row.parentElement;
-            if (row) row.click();
+            // Click the label directly. React attaches handlers via delegation at
+            // the root (element.onclick is null on React nodes), so walking up
+            // looking for a non-null .onclick exhausts to null and never fires.
+            // A click on the label bubbles to React's root listener, triggering
+            // the row's onClick (PR #77 Claude review).
+            label.click();
             return true;
           })()`
           )

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -3,6 +3,7 @@ import { RunStateObserver } from './run-state.ts';
 import { isPreviewIframeSrc, previewIframeVariant, isBootstrapShellHtml } from './preview-host.ts';
 import { isCdpEnabled } from './cdp-env.ts';
 import { OopifHtmlReader } from './oopif-reader.ts';
+import { OPEN_FILES_PANEL_EXPR } from './file-panel.ts';
 
 // Every UI anchor this MCP depends on to work. Grouped by the surface state
 // they live on. A regression in Claude Design's UI will trip one or more of
@@ -583,23 +584,9 @@ export const UI_ANCHORS: AnchorDef[] = [
       // hit "Signup Wireframes (standalone)") it found 0 and false-failed while
       // `designer files` worked. Open the panel first so the anchor exercises the
       // same path. Idempotent + best-effort (matches listFilesDetailed).
-      const openFilesPanel = (): Promise<boolean> =>
-        b
-          .evalValue<boolean>(
-            `(() => {
-            const spans = Array.from(document.querySelectorAll('span'));
-            const label = spans.find((s) => s.children.length === 0 && (s.textContent || '').trim() === 'Design Files');
-            if (!label) return false;
-            // Click the label directly. React attaches handlers via delegation at
-            // the root (element.onclick is null on React nodes), so walking up
-            // looking for a non-null .onclick exhausts to null and never fires.
-            // A click on the label bubbles to React's root listener, triggering
-            // the row's onClick (PR #77 Claude review).
-            label.click();
-            return true;
-          })()`
-          )
-          .catch(() => false);
+      // Shared, idempotent opener (file-panel.ts) — identical to the production
+      // listFilesDetailed opener so this probe exercises the real path.
+      const openFilesPanel = (): Promise<boolean> => b.evalValue<boolean>(OPEN_FILES_PANEL_EXPR).catch(() => false);
 
       // Open the panel ONCE up front. Clicking it on every retry would toggle an
       // already-open panel closed mid-settle (oscillation — review below-gate);


### PR DESCRIPTION
## Summary

Hardens `designer` against the current `claude.ai/design` DOM. Four commits on top of 0.3.14:

1. **`feat(resilience)` — interstitial pre-flight + selector-drift repair.** A pre-flight (`clearInterstitials`, wired through `ensureReady`/`createSession`) detects and handles the three live overlays so verbs don't silently stall: the 495k-token banner (→ "Continue here", keeps context), a transient "Something went wrong" page (→ reload), and the Cloudflare bot-check (→ wait-then-surface). Exposed as `designer clear` / `session action:"clear"` (CLI + MCP). Also repairs the `2026-06-19` home-card rename **"Prototype" → "Product prototype"** and the `fileListScrape` false-fail on single-file projects (open the Design Files panel before scraping; active-`?file=` mismatch is informational).

2. **`feat(health)` — two probes.** `session.oopifPreviewRead` attaches its own `OopifHtmlReader` and asserts the CDP read returns rendered HTML, not the ~1.1KB loader shell or null — closing the gap where `iframeSrcPattern`/`previewBootstrap` pass on the src string while the actual capture is broken. `ci-health.ts` records `interstitial:<kind>|null` in every artifact so a wall of anchor failures isn't misattributed to selector drift when an overlay was the real cause.

3. **`fix(interstitials)` — code-review fixes (2×P1, 3×P2, P3).** The structural fix: `classifyInterstitial` gates the *takeover* kinds (cloudflare, transient-error) on **app-shell-absence** (`appShellPresent`), so chat-transcript text mentioning "verify you are human" / "something went wrong" can no longer false-block every verb. Masked-tab recovery is **scoped to the stored project** (an unscoped `/design` filter could bind the key to an unrelated project). Token banner is non-blocking; `'i'`-flag on the click; `continueHere` override threaded into detection; reload guards empty-URL + uses `'load'` not `'networkidle'`; failed probe ≠ "cleared"; standalone `clear` runs `ensureCdpUp` first; `handled[]` records only re-probe-confirmed clears; `assertNever` on the action dispatch; shared `INTERSTITIAL_PROBE_EXPR`.

4. **`refactor` — meta/refactor/casting/naming polish.** Extract `_classifyOpts`; replace a non-null assertion with native narrowing; `previewIframeSrc` → `getPreviewIframeSrc` (repo `get*` dialect).

## Verification

- `tsc --noEmit` clean · **61 tests** (`npm test`) · `designer health` **15 ok / 0 fail** in-session (both home card anchors pass on home).
- **Live (Chrome 149):** dismissed a real 483k-token banner (context preserved); `oopifPreviewRead` read 81,150 B of rendered HTML; `probeInterstitial` correctly classified the live token banner.

## Related

- Resolves the inbox report `cli-mcp-stale-claude-ai-dom` (prompt/handoff/iframe/designUrl were already fixed in 0.3.14; this adds interstitials).
- Supersedes auto-heal PRs **#75 / #76** — the `home.highFiButton` drift they flagged is fixed here, and the `fileListScrape` false-fail is repaired + the OOPIF read is now probed end-to-end. Safe to close both once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)