### PR TITLE
fix(handoff): rework for the 2026-06-21 Share redesign (in-page export fetch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MCP + CLI that lets your coding agent drive **[claude.ai/design](https://claude.ai/design)** (Claude's wireframe + hi-fi design tool, no API) with full context of your codebase — capabilities, data shape, existing tokens fed into every prompt.
 
-Human describes intent → agent surveys codebase and prompts Claude Design → hands you the URL → iterate → `designer_handoff` bundles the result (README + chats + HTML + JSX) back into your repo.
+Human describes intent → agent surveys codebase and prompts Claude Design → hands you the URL → iterate → `designer_handoff` fetches the project export zip into your repo (`project/` design files + a regenerated `decision-record.md`).
 
 > **Status:** v0.3.14, early. macOS only.
 
@@ -95,7 +95,7 @@ Six tools, registered at user scope by `designer setup`:
 | `designer_ask` | Q&A with the assistant, no file changes. |
 | `designer_list` | `projects` or `files` (flat-only — see quirks). |
 | `designer_snapshot` | Capture current file. Paths + hash by default; `includeHtml: true` inlines. |
-| `designer_handoff` | Export → download + extract tar.gz. Auto-repairs em-dash filename bugs. |
+| `designer_handoff` | Fetch + extract the project export zip → `project/` + `decision-record.md`. Auto-repairs em-dash filename bugs. |
 
 ## The loop
 

--- a/cli.ts
+++ b/cli.ts
@@ -351,7 +351,7 @@ File / project introspection:
   fetch "<name>.html" [--key k] [--out p]      fetch served HTML to disk
 
 Exit / promotion:
-  handoff [--key k] [--file "<name>.html"]     download tar.gz bundle (README + chats + source)
+  handoff [--key k] [--file "<name>.html"]     fetch export zip → project/ + decision-record.md
   tasting [--key k]                            local full-viewport switcher for the latest bundle
                                                (fallback when Claude's URL framing hurts taste)
 

--- a/cli.ts
+++ b/cli.ts
@@ -265,15 +265,10 @@ async function main(): Promise<void> {
         .sort();
       const latest = handoffs[handoffs.length - 1];
       if (!latest) throw new Error(`No handoff bundle found for key=${key}. Run 'designer handoff --key ${key}' first.`);
-      const slugDirs = fs
-        .readdirSync(latest)
-        .filter((e) => e !== 'bundle.tar.gz')
-        .map((e) => path.join(latest, e))
-        .filter((p) => fs.statSync(p).isDirectory());
-      const slugDir = slugDirs[0];
-      if (!slugDir) throw new Error('Bundle has no project subdirectory.');
-      const projectDir = path.join(slugDir, 'project');
-      if (!fs.existsSync(projectDir)) throw new Error(`Missing ${projectDir}`);
+      // The bundle is now flat: handoff-<ts>/project/ holds the unzipped files
+      // directly (no <slug>/ subdir — the 2026-06 export zip is flat).
+      const projectDir = path.join(latest, 'project');
+      if (!fs.existsSync(projectDir)) throw new Error(`Missing ${projectDir} — re-run 'designer handoff --key ${key}'.`);
 
       // Walk recursively — Claude Design organizes variants under folders
       // (e.g. directions/*.html) often enough that flat readdir misses them.
@@ -449,19 +444,24 @@ Flags:
 Output: prints 'Taste here: <url>' then JSON with { file, url, htmlBytes, screenshotPath }.
 Useful when you want to inspect a variant or save the current state to disk without iterating.`,
 
-  handoff: `designer handoff — trigger Export→Handoff and download the tar.gz bundle.
+  handoff: `designer handoff — fetch the project export zip and extract a local bundle.
 
 Flags:
   --key <k>               session to target
-  --file <name.html>      switch to this file first (marks it as the primary in the bundle)
+  --file <name.html>      switch to this file first
 
-Bundle contains:
-  README.md       handoff protocol for the implementing agent
-  chats/chat1.md  full transcript — every prompt + reply, verbatim (the decision record)
-  project/*       all design files (HTML, standalone HTML, JSX, CSS)
+How it works: GETs the project's export zip from the authenticated same-origin
+endpoint (/design/v1/design/projects/<id>/download) in-page — no browser download
+gesture needed — then unzips it.
 
-Lands under ./artifacts/{key}/handoff-{timestamp}/. Non-optional for code promotion — the
-implementing agent (Claude Code downstream) reads README + chats first, then builds in real code.`,
+Bundle (./artifacts/{key}/handoff-{timestamp}/):
+  bundle.zip          the raw export archive
+  project/*           all design files (HTML, standalone HTML, CSS, JS) + screenshots/
+  decision-record.md  full chat transcript, verbatim — regenerated from the live
+                      session, since the export zip no longer ships it
+
+Non-optional for code promotion — the implementing agent reads decision-record.md
+first (the why), then builds from project/ in real code.`,
 
   tasting: `designer tasting — build a local full-viewport switcher over the latest handoff bundle.
 

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -115,13 +115,20 @@ export interface AskResult {
 
 export interface HandoffResult {
   ok: true;
-  handoffUrl: string;
+  projectId: string;
+  projectUrl: string;
   bundleDir: string;
+  /** Alias of bundleDir (the bundle root). Kept so downstream consumers that
+   *  expected a slug subdir keep resolving; the new export zip is flat. */
   slugDir: string;
-  readmePath: string;
-  readmeBytes: number;
-  tarballPath: string;
-  tarballBytes: number;
+  /** Where the unzipped design files live (bundleDir/project). */
+  projectDir: string;
+  /** Self-generated from the live chat — the export zip no longer ships the
+   *  README/transcript the old tar.gz did. */
+  decisionRecordPath: string;
+  decisionRecordBytes: number;
+  zipPath: string;
+  zipBytes: number;
   files: string[];
   repaired: RepairReport;
 }
@@ -1303,75 +1310,98 @@ export class DesignerController {
     return OopifHtmlReader.attach({ preferUrlPrefix: (await this.currentUrl()) || null }).catch(() => null);
   }
 
+  // Fetch the project's export zip via the authenticated, same-origin endpoint
+  // the Share→Export "Download" button hits — `/design/v1/design/projects/<id>
+  // /download` (returns application/zip). The 2026-06-21 redesign removed the old
+  // public `api.anthropic.com/v1/design/h/<id>` tar.gz URL and replaced it with a
+  // browser download that needs a trusted gesture CDP can't fire — but the bytes
+  // come from a plain GET. We do it IN-PAGE (auth + Cloudflare just work there; a
+  // node-side fetch with copied cookies 403s) and transfer the bytes out as
+  // base64. Throws on non-200 / non-zip so the caller surfaces a clear failure.
+  private async _downloadProjectZip(projectId: string): Promise<Buffer> {
+    // Origin guard: the in-page fetch is same-origin, so if the bound tab has
+    // drifted off claude.ai (tab drift is real — it bit this very session) the
+    // '/design/v1/...' path would resolve against the wrong app and 404. Refuse
+    // rather than return junk.
+    const url = await this.currentUrl();
+    if (!/^https:\/\/claude\.ai\/design\//.test(url)) {
+      throw new Error(`Active tab is not on claude.ai/design (${url || 'unknown'}) — refusing to fetch the export from the wrong origin.`);
+    }
+    const expr = `(async () => {
+      try {
+        const r = await fetch('/design/v1/design/projects/' + ${JSON.stringify(projectId)} + '/download', { headers: { Accept: '*/*' } });
+        if (!r.ok) return 'ERR ' + r.status;
+        const bytes = new Uint8Array(await r.arrayBuffer());
+        let bin = '';
+        const CH = 0x8000;
+        for (let i = 0; i < bytes.length; i += CH) bin += String.fromCharCode.apply(null, bytes.subarray(i, i + CH));
+        return btoa(bin);
+      } catch (e) { return 'ERR ' + (e && e.message || e); }
+    })()`;
+    const out = (await this.browser.eval(expr)).trim();
+    let b64 = out;
+    if (b64.startsWith('"') && b64.endsWith('"')) b64 = JSON.parse(b64);
+    if (b64.startsWith('ERR')) throw new Error(`Project download failed (${b64.slice(4).trim()}). Are you signed in to claude.ai/design?`);
+    const buf = Buffer.from(b64, 'base64');
+    if (buf.length < 100 || buf.subarray(0, 2).toString('latin1') !== 'PK') {
+      throw new Error(`Project download did not return a zip (${buf.length} bytes).`);
+    }
+    return buf;
+  }
+
   async handoff({ openFile }: { openFile?: string } = {}): Promise<HandoffResult> {
     await this._ensureInSession();
     if (openFile) await this.openFile(openFile);
 
-    // Claude.ai/design moved Export actions under the Share dropdown
-    // (~2026-04-19). Try Share first; fall back to Export for older builds.
-    const opened = await this._clickButtonByText(/^Share$/).catch(() => null);
-    if (!opened) await this._clickButtonByText(/^Export$/);
-    await new Promise((r) => setTimeout(r, 400));
-    // ~2026-06: Share opens a tabbed dialog; handoff lives under the
-    // "Send to…" tab as a "Claude Code" destination row. Older builds had a
-    // direct "Handoff to Claude Code" menu item — keep it as the fallback.
-    const viaSendTo = await this._clickClaudeCodeSendTo().catch(() => false);
-    if (!viaSendTo) await this._clickButtonByText(/handoff to claude code/i);
+    const baseUrl = getSession(this.key)?.designUrl || (await this.currentUrl());
+    const m = baseUrl.match(SESSION_URL_RE);
+    if (!m || !m[1]) throw new Error(`No /design/p/<uuid> project bound to key=${this.key} to hand off.`);
+    const projectId = m[1];
+    const projectUrl = baseUrl.split('?')[0] ?? baseUrl;
 
-    let handoffUrl = '';
-    for (let i = 0; i < 30; i++) {
-      await new Promise((r) => setTimeout(r, 300));
-      const text = await this._dialogText();
-      const match = String(text || '').match(/https:\/\/api\.anthropic\.com\/v1\/design\/h\/[A-Za-z0-9_-]+(?:\?[^\s]*)?/);
-      if (match && match[0]) {
-        handoffUrl = match[0];
-        break;
-      }
-    }
-    if (!handoffUrl) throw new Error('Handoff URL did not appear in the dialog.');
+    // The export zip dropped the README + chat transcript the old tar.gz carried,
+    // so regenerate the decision record from the live chat before downloading.
+    const turns = await this.getChatTurns().catch((): ChatTurn[] => []);
+    const decisionRecord = renderDecisionRecord(turns, projectId, projectUrl);
 
-    await this.browser
-      .evalValue<boolean>(`document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))`)
-      .catch(() => null);
+    const zip = await this._downloadProjectZip(projectId);
 
     const dir = sessionDir(this.key);
     const stamp = new Date().toISOString().replace(/[:.]/g, '-');
     const bundleDir = path.join(dir, `handoff-${stamp}`);
-    fs.mkdirSync(bundleDir, { recursive: true });
-    const tgzPath = path.join(bundleDir, 'bundle.tar.gz');
+    const projectDir = path.join(bundleDir, 'project');
+    fs.mkdirSync(projectDir, { recursive: true });
+    const zipPath = path.join(bundleDir, 'bundle.zip');
+    fs.writeFileSync(zipPath, zip);
 
-    const res = await fetch(handoffUrl);
-    if (!res.ok) throw new Error(`Handoff fetch failed: HTTP ${res.status}`);
-    const buf = Buffer.from(await res.arrayBuffer());
-    fs.writeFileSync(tgzPath, buf);
-
+    // Unzip the flat archive into project/. unzip exit 1 = non-fatal warnings.
     await new Promise<void>((resolve, reject) => {
-      const child = xspawn('tar', ['-xzf', tgzPath, '-C', bundleDir], { stdio: 'pipe' });
+      const child = xspawn('unzip', ['-o', '-q', zipPath, '-d', projectDir], { stdio: 'pipe' });
       let err = '';
       child.stderr!.on('data', (d: Buffer) => (err += d.toString()));
       child.on('close', (code: number | null) =>
-        code === 0 ? resolve() : reject(new Error(`tar exited ${code}: ${err}`))
+        code === 0 || code === 1 ? resolve() : reject(new Error(`unzip exited ${code}: ${err}`))
       );
     });
 
-    const entries = fs.readdirSync(bundleDir).filter((e) => e !== 'bundle.tar.gz');
-    const projectSlug = entries.find((e) => fs.statSync(path.join(bundleDir, e)).isDirectory());
-    const slugDir = projectSlug ? path.join(bundleDir, projectSlug) : bundleDir;
-    const repaired = repairEmDashLinks(path.join(slugDir, 'project'));
-    const readmePath = path.join(slugDir, 'README.md');
-    const readme = fs.existsSync(readmePath) ? fs.readFileSync(readmePath, 'utf8') : null;
-    const files = listAllFiles(slugDir).map((p) => path.relative(bundleDir, p));
+    const decisionRecordPath = path.join(bundleDir, 'decision-record.md');
+    fs.writeFileSync(decisionRecordPath, decisionRecord);
 
-    appendHistory(this.key, { kind: 'handoff', url: handoffUrl, bundleDir, fileCount: files.length, repaired });
+    const repaired = repairEmDashLinks(projectDir);
+    const files = listAllFiles(bundleDir).map((p) => path.relative(bundleDir, p));
+
+    appendHistory(this.key, { kind: 'handoff', projectId, bundleDir, fileCount: files.length, repaired });
     return {
       ok: true,
-      handoffUrl,
+      projectId,
+      projectUrl,
       bundleDir,
-      slugDir,
-      readmePath,
-      readmeBytes: readme ? readme.length : 0,
-      tarballPath: tgzPath,
-      tarballBytes: buf.length,
+      slugDir: bundleDir,
+      projectDir,
+      decisionRecordPath,
+      decisionRecordBytes: Buffer.byteLength(decisionRecord),
+      zipPath,
+      zipBytes: zip.length,
       files,
       repaired
     };
@@ -1390,51 +1420,6 @@ export class DesignerController {
     );
   }
 
-  // Navigate the tabbed Share dialog (2026-06 layout): "Send to…" tab →
-  // "Claude Code" destination row → its Send button. The row's Send button
-  // has no testid and its label text ("Claude Code", "Hand off the project
-  // to your terminal") lives in sibling elements, so match by walking up to
-  // the row container. Returns false if the tab or row isn't there, so the
-  // caller can fall back to the legacy direct menu item.
-  async _clickClaudeCodeSendTo(): Promise<boolean> {
-    const tabClicked = await this.browser.evalValue<boolean>(
-      `(() => {
-        const tab = Array.from(document.querySelectorAll('button[role="tab"]')).find(t => /send to/i.test(t.textContent || ''));
-        if (!tab) return false;
-        tab.click();
-        return true;
-      })()`
-    );
-    if (!tabClicked) return false;
-    await new Promise((r) => setTimeout(r, 400));
-    return this.browser.evalValue<boolean>(
-      `(() => {
-        const sends = Array.from(document.querySelectorAll('button')).filter(b => (b.textContent || '').trim() === 'Send');
-        const target = sends.find(b => {
-          let row = b;
-          for (let i = 0; i < 3 && row.parentElement; i++) row = row.parentElement;
-          return /claude code/i.test(row.textContent || '');
-        });
-        if (!target) return false;
-        target.click();
-        return true;
-      })()`
-    );
-  }
-
-  async _dialogText(): Promise<string> {
-    return (
-      (await this.browser
-        .evalValue<string>(
-          `(() => {
-            const dlg = document.querySelector('[role=dialog]');
-            return (dlg && dlg.innerText) || '';
-          })()`
-        )
-        .catch(() => '')) || ''
-    );
-  }
-
   async close(): Promise<void> {
     await this.browser.close().catch(() => null);
   }
@@ -1446,6 +1431,40 @@ function hashHex(s: string): string {
 
 function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// The export zip no longer ships the README + chat transcript the old tar.gz
+// did, so reconstruct a decision record from the live chat turns (every prompt +
+// reply, verbatim) — the "why" a coding agent needs alongside the files.
+function renderDecisionRecord(turns: ChatTurn[], projectId: string, projectUrl: string): string {
+  // getChatTurns role-detects off the turn text starting with "Claude"/"You";
+  // the current chat DOM dropped those text labels (turns carry only data-index),
+  // so roles can come back all-'unknown'. Don't mislabel them "Note" — fall back
+  // to sequential "Turn N" and flag the gap. (Role attribution is a separate
+  // getChatTurns drift, tracked independently.)
+  const attributed = turns.some((t) => t.role !== 'unknown');
+  const out = [
+    '# Design handoff — decision record',
+    '',
+    `Project: ${projectUrl}`,
+    `Project ID: ${projectId}`,
+    `Captured: ${new Date().toISOString()}`,
+    ''
+  ];
+  if (!turns.length) {
+    out.push('## Conversation', '', '_(no chat turns captured)_');
+    return out.join('\n');
+  }
+  out.push('## Conversation (verbatim — the decisions behind the design)');
+  if (!attributed) {
+    out.push('', '_Speaker labels unavailable (claude.ai dropped role markers from the chat DOM); turns are shown in order._');
+  }
+  out.push('');
+  turns.forEach((t, i) => {
+    const role = t.role === 'assistant' ? 'Claude' : t.role === 'user' ? 'You' : `Turn ${i + 1}`;
+    out.push(`### ${role}`, '', t.text.trim(), '');
+  });
+  return out.join('\n');
 }
 
 function extractFileParam(url: string): string | null {

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import crypto from 'node:crypto';
-import { xspawn } from './cross-platform.ts';
 import { createBrowser, type Browser } from './browser.ts';
 import { sessionDir, saveIteration, type IterationRecord } from './artifact-store.ts';
 import { upsertSession, appendHistory, getSession, type StoredSession } from './session-store.ts';
@@ -23,6 +22,7 @@ import {
   type InterstitialReport
 } from './interstitials.ts';
 import { OPEN_FILES_PANEL_EXPR } from './file-panel.ts';
+import { unzipSync } from 'fflate';
 
 export interface Selectors {
   login: { signedInIndicator: string | null };
@@ -127,8 +127,14 @@ export interface HandoffResult {
    *  README/transcript the old tar.gz did. */
   decisionRecordPath: string;
   decisionRecordBytes: number;
+  /** Chat turns captured into the decision record. */
+  decisionRecordTurns: number;
+  /** True when no chat turns were captured — the record is header-only (the
+   *  caller advertises a verbatim transcript, so surface the gap). */
+  decisionRecordEmpty: boolean;
   zipPath: string;
   zipBytes: number;
+  /** Design files under project/ (NOT the zip or the record). */
   files: string[];
   repaired: RepairReport;
 }
@@ -1331,26 +1337,105 @@ export class DesignerController {
     if (!/^https:\/\/claude\.ai\/design\//.test(url)) {
       throw new Error(`Active tab is not on claude.ai/design (${url || 'unknown'}) — refusing to fetch the export from the wrong origin.`);
     }
-    const expr = `(async () => {
+    // In-page authed GET with an abort deadline; returns {status, bytes, b64} or
+    // {status, err}. Bytes are carried out as chunked base64 (byte-exact); the
+    // server byte count comes back too so we can detect a truncated transfer.
+    const expr = (timeoutMs: number) => `(async () => {
+      const ctrl = new AbortController();
+      const to = setTimeout(() => ctrl.abort(), ${timeoutMs});
       try {
-        const r = await fetch('/design/v1/design/projects/' + ${JSON.stringify(projectId)} + '/download', { headers: { Accept: '*/*' } });
-        if (!r.ok) return 'ERR ' + r.status;
+        const r = await fetch('/design/v1/design/projects/' + ${JSON.stringify(projectId)} + '/download', { headers: { Accept: '*/*' }, signal: ctrl.signal });
+        if (!r.ok) return { status: r.status };
         const bytes = new Uint8Array(await r.arrayBuffer());
         let bin = '';
         const CH = 0x8000;
         for (let i = 0; i < bytes.length; i += CH) bin += String.fromCharCode.apply(null, bytes.subarray(i, i + CH));
-        return btoa(bin);
-      } catch (e) { return 'ERR ' + (e && e.message || e); }
+        return { status: 200, bytes: bytes.length, b64: btoa(bin) };
+      } catch (e) { return { status: 0, err: String((e && e.message) || e) }; }
+      finally { clearTimeout(to); }
     })()`;
-    const out = (await this.browser.eval(expr)).trim();
-    let b64 = out;
-    if (b64.startsWith('"') && b64.endsWith('"')) b64 = JSON.parse(b64);
-    if (b64.startsWith('ERR')) throw new Error(`Project download failed (${b64.slice(4).trim()}). Are you signed in to claude.ai/design?`);
-    const buf = Buffer.from(b64, 'base64');
-    if (buf.length < 100 || buf.subarray(0, 2).toString('latin1') !== 'PK') {
-      throw new Error(`Project download did not return a zip (${buf.length} bytes).`);
+
+    // Bounded retry: fail fast on auth/not-found, retry transient (abort/0/429/5xx).
+    let lastErr = 'unknown';
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const res = await this.browser
+        .evalValue<{ status: number; bytes?: number; b64?: string; err?: string }>(expr(25_000))
+        .catch((e): { status: number; bytes?: number; b64?: string; err?: string } => ({ status: 0, err: String((e as Error)?.message || e) }));
+      if (res.status === 200 && typeof res.b64 === 'string') {
+        const buf = Buffer.from(res.b64, 'base64');
+        if (typeof res.bytes === 'number' && buf.length !== res.bytes) {
+          lastErr = `truncated transfer (${buf.length} of ${res.bytes} bytes)`; // retry
+        } else if (buf.length < 100 || buf.subarray(0, 2).toString('latin1') !== 'PK') {
+          throw new Error(`Project download is not a zip (${buf.length} bytes).`);
+        } else {
+          return buf;
+        }
+      } else {
+        lastErr = res.err ? res.err : `HTTP ${res.status}`;
+        if (res.status === 401 || res.status === 403 || res.status === 404) {
+          throw new Error(`Project download failed (HTTP ${res.status}). Are you signed in to claude.ai/design?`);
+        }
+      }
+      if (attempt < 2) await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
     }
-    return buf;
+    throw new Error(`Project download failed after 3 attempts: ${lastErr}.`);
+  }
+
+  // Capture the FULL chat transcript despite virtualization (claude.ai mounts only
+  // the visible rows). Scroll the chat history top→bottom, accumulating turns keyed
+  // by data-index so rows that unmount as we scroll are still kept. Best-effort: if
+  // the scroll container isn't found, degrades to the visible window.
+  private async _collectChatTurns(): Promise<ChatTurn[]> {
+    const collected = new Map<number, ChatTurn>();
+    const scrape = async (): Promise<void> => {
+      const rows = await this.browser
+        .evalValue<Array<{ idx: number; role: 'assistant' | 'user'; text: string }>>(
+          `(() => {
+            const c = document.querySelector('[data-testid="chat-messages"]');
+            const inner = c && c.children[0];
+            if (!inner) return [];
+            return Array.from(inner.children).map((d) => {
+              const idx = parseInt(d.getAttribute('data-index') || '-1', 10);
+              const txt = (d.innerText || '').trim();
+              const isAssistant = !!d.querySelector('[data-msgfb]') || /^Claude(\\n|$)/.test(txt);
+              return { idx, role: isAssistant ? 'assistant' : 'user', text: txt };
+            });
+          })()`
+        )
+        .catch(() => [] as Array<{ idx: number; role: 'assistant' | 'user'; text: string }>);
+      for (const r of rows) if (r.idx >= 0 && r.text) collected.set(r.idx, { role: r.role, text: r.text });
+    };
+    const scroll = (dir: 'top' | 'down'): Promise<number> =>
+      this.browser
+        .evalValue<number>(
+          `(() => {
+            let s = document.querySelector('[data-testid="chat-messages"]');
+            for (let i = 0; i < 8 && s; i++) { if (s.scrollHeight > s.clientHeight + 4) break; s = s.parentElement; }
+            if (!s) return -1;
+            if (${JSON.stringify(dir)} === 'top') s.scrollTop = 0; else s.scrollTop = Math.min(s.scrollTop + s.clientHeight, s.scrollHeight);
+            return s.scrollTop;
+          })()`
+        )
+        .catch(() => -1);
+
+    await scroll('top');
+    await new Promise((r) => setTimeout(r, 400));
+    let lastTop = -2;
+    let stable = 0;
+    for (let i = 0; i < 40; i++) {
+      await scrape();
+      const top = await scroll('down');
+      if (top < 0) break; // no scroller — single visible-window pass
+      await new Promise((r) => setTimeout(r, 250));
+      if (top === lastTop) {
+        if (++stable >= 2) break;
+      } else {
+        stable = 0;
+        lastTop = top;
+      }
+    }
+    await scrape();
+    return [...collected.entries()].sort((a, b) => a[0] - b[0]).map(([, t]) => t);
   }
 
   async handoff({ openFile }: { openFile?: string } = {}): Promise<HandoffResult> {
@@ -1363,52 +1448,72 @@ export class DesignerController {
     const projectId = m[1];
     const projectUrl = baseUrl.split('?')[0] ?? baseUrl;
 
+    // Cross-project guard: the in-page chat scrape AND the export fetch run on the
+    // ACTIVE tab. _ensureInSession returns early on any /design/p/ tab and tab
+    // drift is real, so the active tab can be a DIFFERENT project than the bound
+    // one — which would pair project B's chat with project A's files. Pin the tab
+    // to the bound project first so both come from one project.
+    const curId = (await this.currentUrl()).match(SESSION_URL_RE)?.[1];
+    if (curId !== projectId) await this.resumeSession();
+
     // The export zip dropped the README + chat transcript the old tar.gz carried,
-    // so regenerate the decision record from the live chat before downloading.
-    const turns = await this.getChatTurns().catch((): ChatTurn[] => []);
+    // so regenerate the decision record from the live chat (virtualization-aware).
+    const turns = await this._collectChatTurns().catch((): ChatTurn[] => []);
     const decisionRecord = renderDecisionRecord(turns, projectId, projectUrl);
 
     const zip = await this._downloadProjectZip(projectId);
 
+    // Build the bundle atomically: assemble in a temp dir, rename into place only
+    // on full success, so a crash/partial extract never leaves a half-built bundle
+    // that `tasting` would pick up as the latest complete handoff.
     const dir = sessionDir(this.key);
     const stamp = new Date().toISOString().replace(/[:.]/g, '-');
     const bundleDir = path.join(dir, `handoff-${stamp}`);
-    const projectDir = path.join(bundleDir, 'project');
-    fs.mkdirSync(projectDir, { recursive: true });
-    const zipPath = path.join(bundleDir, 'bundle.zip');
-    fs.writeFileSync(zipPath, zip);
+    const tmpDir = path.join(dir, `.handoff-${stamp}.tmp`);
+    const tmpProject = path.join(tmpDir, 'project');
+    fs.mkdirSync(tmpProject, { recursive: true });
+    try {
+      // Extract in-process (no external `unzip` — absent on Windows / minimal CI).
+      const entries = unzipSync(new Uint8Array(zip));
+      let extracted = 0;
+      for (const [name, data] of Object.entries(entries)) {
+        if (!name || name.endsWith('/')) continue;
+        const dest = path.join(tmpProject, name);
+        if (dest !== tmpProject && !dest.startsWith(tmpProject + path.sep)) continue; // zip-slip guard
+        fs.mkdirSync(path.dirname(dest), { recursive: true });
+        fs.writeFileSync(dest, Buffer.from(data));
+        extracted++;
+      }
+      if (extracted === 0) throw new Error('export zip contained no files');
+      fs.writeFileSync(path.join(tmpDir, 'bundle.zip'), zip);
+      fs.writeFileSync(path.join(tmpDir, 'decision-record.md'), decisionRecord);
+      const repaired = repairEmDashLinks(tmpProject);
+      fs.renameSync(tmpDir, bundleDir); // commit
 
-    // Unzip the flat archive into project/. unzip exit 1 = non-fatal warnings.
-    await new Promise<void>((resolve, reject) => {
-      const child = xspawn('unzip', ['-o', '-q', zipPath, '-d', projectDir], { stdio: 'pipe' });
-      let err = '';
-      child.stderr!.on('data', (d: Buffer) => (err += d.toString()));
-      child.on('close', (code: number | null) =>
-        code === 0 || code === 1 ? resolve() : reject(new Error(`unzip exited ${code}: ${err}`))
-      );
-    });
-
-    const decisionRecordPath = path.join(bundleDir, 'decision-record.md');
-    fs.writeFileSync(decisionRecordPath, decisionRecord);
-
-    const repaired = repairEmDashLinks(projectDir);
-    const files = listAllFiles(bundleDir).map((p) => path.relative(bundleDir, p));
-
-    appendHistory(this.key, { kind: 'handoff', projectId, bundleDir, fileCount: files.length, repaired });
-    return {
-      ok: true,
-      projectId,
-      projectUrl,
-      bundleDir,
-      slugDir: bundleDir,
-      projectDir,
-      decisionRecordPath,
-      decisionRecordBytes: Buffer.byteLength(decisionRecord),
-      zipPath,
-      zipBytes: zip.length,
-      files,
-      repaired
-    };
+      const projectDir = path.join(bundleDir, 'project');
+      // Design inventory = project/ only (the zip + record aren't design files).
+      const files = listAllFiles(projectDir).map((p) => path.relative(bundleDir, p));
+      appendHistory(this.key, { kind: 'handoff', projectId, bundleDir, fileCount: files.length, turns: turns.length, repaired });
+      return {
+        ok: true,
+        projectId,
+        projectUrl,
+        bundleDir,
+        slugDir: bundleDir,
+        projectDir,
+        decisionRecordPath: path.join(bundleDir, 'decision-record.md'),
+        decisionRecordBytes: Buffer.byteLength(decisionRecord),
+        decisionRecordTurns: turns.length,
+        decisionRecordEmpty: turns.length === 0,
+        zipPath: path.join(bundleDir, 'bundle.zip'),
+        zipBytes: zip.length,
+        files,
+        repaired
+      };
+    } catch (e) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      throw e;
+    }
   }
 
   async _clickButtonByText(pattern: RegExp | string): Promise<boolean> {

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -1150,9 +1150,13 @@ export class DesignerController {
             if (!inner) return [];
             return Array.from(inner.children).map((d) => {
               const txt = (d.innerText || '').trim();
-              const isAssistant = /^Claude(\\n|$)/.test(txt);
-              const isUser = /^You(\\n|$)/.test(txt);
-              return { role: isAssistant ? 'assistant' : isUser ? 'user' : 'unknown', text: txt };
+              // Role signal: Claude's replies carry a feedback widget
+              // ([data-msgfb], thumbs up/down) and user turns don't. The 2026-06
+              // chat DOM dropped the "Claude"/"You" text prefixes the old check
+              // keyed off (kept as a fallback for older builds). In this two-party
+              // chat a non-assistant turn is the human, so default to 'user'.
+              const isAssistant = !!d.querySelector('[data-msgfb]') || /^Claude(\\n|$)/.test(txt);
+              return { role: isAssistant ? 'assistant' : 'user', text: txt };
             });
           })()`
         )

--- a/mcp-server.ts
+++ b/mcp-server.ts
@@ -157,7 +157,7 @@ server.registerTool(
   'designer_handoff',
   {
     description:
-      "Promote: trigger Export → Handoff to Claude Code, download the public tar.gz bundle (no auth), extract under ./artifacts/{key}/handoff-{ts}/. Bundle contains README.md, chat transcripts (decision record — every prompt + reply, verbatim), all design files, standalone HTML, shared CSS, design-canvas.jsx. Call when the human says 'yes, that's it'.",
+      "Promote: fetch the project's export zip from the authenticated same-origin endpoint (/design/v1/design/projects/<id>/download) and extract it under ./artifacts/{key}/handoff-{ts}/project/. Also writes decision-record.md regenerated from the live chat (every prompt + reply, verbatim — the export zip no longer ships it). project/ holds all design files (HTML, standalone HTML, CSS, JS) + screenshots/. Call when the human says 'yes, that's it'.",
     inputSchema: {
       key: z.string().optional(),
       openFile: z.string().optional().describe('Set the open file before handoff.')

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@anthropic-ai/sdk": "^0.104.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "cross-spawn": "^7.0.6",
+        "fflate": "^0.8.3",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -930,6 +931,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1013,6 +1015,12 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
@@ -1155,6 +1163,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
       "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1790,6 +1799,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@anthropic-ai/sdk": "^0.104.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "cross-spawn": "^7.0.6",
+    "fflate": "^0.8.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/skills/designer-loop/SKILL.md
+++ b/skills/designer-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: designer-loop
-description: "Human-participated design iteration loop driven by claude.ai/design via the `designer` MCP. The human is the designer; AI is translation + plumbing. Human states intent, AI reads what exists and relays intent to Claude Design, human tastes the variants Claude produces, AI interprets reactions and iterates. Promotes accepted result with a decision record (the bundle's chat transcript)."
+description: "Human-participated design iteration loop driven by claude.ai/design via the `designer` MCP. The human is the designer; AI is translation + plumbing. Human states intent, AI reads what exists and relays intent to Claude Design, human tastes the variants Claude produces, AI interprets reactions and iterates. Promotes accepted result with a decision record (a regenerated decision-record.md)."
 ---
 
 # Designer Loop
@@ -123,11 +123,11 @@ Common loop for any variant shape:
 2. `designer_prompt({ prompt })` — terse, let-Claude-name. The MCP auto-appends a flat-file-layout instruction; if you want subfolders you must explicitly override in your prompt.
 3. **Hand the human the URL** — `designer_session({ key, action: 'status' }).currentUrl`, or the URL echoed in the prompt result. The URL is the live design in Claude's IDE: all tweak sliders work, variant switcher works, fully interactive. This is the default taste path.
 4. Repeat 2-3 as they react.
-5. When they say "that's it": `designer_handoff({ key })` — tar.gz bundle with all variants + README + chat transcript. This is non-optional; it's what the implementing agent needs to build the real thing.
+5. When they say "that's it": `designer_handoff({ key })` — fetches the project export zip into `./artifacts/{key}/handoff-{ts}/`: `project/` with all variants + a regenerated `decision-record.md`. This is non-optional; it's what the implementing agent needs to build the real thing.
 
 ### When `designer_list({ scope: 'files' })` says `authoritative: false`
 
-Claude Design sometimes organizes generated files under folders (`directions/`, `variants/`, `shared/`). The live file-list scrape only sees top-level files + folder names, never contents. When the result includes `folders: […]` and `authoritative: false`, the list is incomplete. Fall back to `designer_handoff` — the tar.gz bundle is always folder-aware.
+Claude Design sometimes organizes generated files under folders (`directions/`, `variants/`, `shared/`). The live file-list scrape only sees top-level files + folder names, never contents. When the result includes `folders: […]` and `authoritative: false`, the list is incomplete. Fall back to `designer_handoff` — the export-zip bundle is always complete (every project file).
 
 ### When the URL isn't enough — full-viewport tasting
 
@@ -174,11 +174,11 @@ Never override with "but best practice says..." — capture the tension in the d
 
 ## Phase 6: Promote
 
-1. `designer_handoff({ key, openFile: <chosen variant> })` — downloads the tar.gz bundle under `./artifacts/{key}/handoff-{ts}/`. The bundle is the decision record:
-   - `README.md` — handoff protocol for the implementing agent
-   - `chats/chat1.md` — full transcript (every prompt + reply, verbatim)
-   - `project/*.html`, `*.jsx`, `*.css` — all design files including the chosen variant
-2. If this is a frontend for an existing codebase, the implementing agent (this one, or Claude Code downstream) reads the bundle's README + chat transcript first, then translates the chosen variant into real code in the target repo.
+1. `designer_handoff({ key, openFile: <chosen variant> })` — fetches the project export zip into `./artifacts/{key}/handoff-{ts}/`:
+   - `decision-record.md` — full transcript (every prompt + reply, verbatim), regenerated from the live chat
+   - `project/*` — all design files (HTML/CSS/JS) including the chosen variant, plus `screenshots/`
+   - `bundle.zip` — the raw export archive
+2. If this is a frontend for an existing codebase, the implementing agent (this one, or Claude Code downstream) reads `decision-record.md` first, then translates the chosen variant from `project/` into real code in the target repo.
 3. Append to the codebase's design decision log with a short entry citing the bundle path + the human's final reaction verbatim.
 
 ## Guardrails

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -492,42 +492,39 @@ export const UI_ANCHORS: AnchorDef[] = [
     check: async (b) => ({ ok: await hasButtonMatching(b, /^Share$/) })
   },
   {
+    // Id kept (not renamed) to preserve the persisted health-streak counter.
+    // Validates the path `designer handoff` actually takes: the same-origin
+    // project export endpoint returns a zip. The old check clicked the Share
+    // dialog and asserted "claude code" TEXT existed — which false-passed (it
+    // stayed green while handoff threw) because it never exercised the real
+    // mechanism (PR: handoff Share-redesign rework).
     id: 'share.handoffMenuItem',
     category: 'share',
-    description: 'Handoff-to-Claude-Code action (Share → Send to… tab → Claude Code row, or the legacy dropdown item)',
+    description: 'Project export endpoint (/design/v1/design/projects/<id>/download) returns a zip — the path designer handoff fetches',
     requires: 'session',
-    check: async (b) => {
-      const opened = await b.evalValue<boolean>(
-        `(() => { const btn = Array.from(document.querySelectorAll('button')).find(x => (x.textContent||'').trim() === 'Share'); if (!btn) return false; btn.click(); return true; })()`
-      ).catch(() => false);
-      if (!opened) return { ok: false, detail: 'Share button not clickable' };
-      await new Promise((r) => setTimeout(r, 400));
-      // Legacy layout (pre 2026-06): direct "Handoff to Claude Code" menu item.
-      let found = await hasButtonMatching(b, /handoff to claude code/i);
-      if (!found) {
-        // 2026-06 layout: Share opens a tabbed dialog; handoff lives under the
-        // "Send to…" tab as a "Claude Code" destination row with a Send button.
-        // Only assert the row exists — clicking Send would mint a handoff link.
-        const tabClicked = await b.evalValue<boolean>(
-          `(() => { const tab = Array.from(document.querySelectorAll('button[role="tab"]')).find(t => /send to/i.test(t.textContent || '')); if (!tab) return false; tab.click(); return true; })()`
-        ).catch(() => false);
-        if (tabClicked) {
-          await new Promise((r) => setTimeout(r, 400));
-          found = await b.evalValue<boolean>(
-            `(() => {
-              const sends = Array.from(document.querySelectorAll('button')).filter(x => (x.textContent || '').trim() === 'Send');
-              return sends.some(x => {
-                let row = x;
-                for (let i = 0; i < 3 && row.parentElement; i++) row = row.parentElement;
-                return /claude code/i.test(row.textContent || '');
-              });
-            })()`
-          ).catch(() => false);
-        }
-      }
-      // close dialog/dropdown
-      await b.evalValue<boolean>(`document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })); true`).catch(() => null);
-      return { ok: found, detail: found ? undefined : 'Share opened but no Claude Code handoff action (checked legacy item and Send to… tab)' };
+    check: async (b, url) => {
+      const m = url.match(/\/design\/p\/([a-f0-9-]+)/i);
+      if (!m || !m[1]) return { ok: true, status: 'skip', detail: 'not in a /design/p/<uuid> session' };
+      const projectId = m[1];
+      // In-page GET (auth + Cloudflare just work there); read headers, cancel the
+      // body so health doesn't pull the multi-MB zip every run.
+      const res = await b
+        .evalValue<{ status: number; ct: string; err?: string }>(
+          `(async () => {
+            try {
+              const r = await fetch('/design/v1/design/projects/' + ${JSON.stringify(projectId)} + '/download', { headers: { Accept: '*/*' } });
+              const o = { status: r.status, ct: r.headers.get('content-type') || '' };
+              try { await r.body.cancel(); } catch {}
+              return o;
+            } catch (e) { return { status: 0, ct: '', err: String((e && e.message) || e) }; }
+          })()`
+        )
+        .catch(() => ({ status: 0, ct: '', err: 'eval failed' }));
+      const ok = res.status === 200 && /zip/i.test(res.ct);
+      return {
+        ok,
+        detail: ok ? `200 ${res.ct}` : `download endpoint status=${res.status} ct=${res.ct}${res.err ? ' err=' + res.err : ''}`
+      };
     }
   },
 

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -507,20 +507,27 @@ export const UI_ANCHORS: AnchorDef[] = [
       if (!m || !m[1]) return { ok: true, status: 'skip', detail: 'not in a /design/p/<uuid> session' };
       const projectId = m[1];
       // In-page GET (auth + Cloudflare just work there); read headers, cancel the
-      // body so health doesn't pull the multi-MB zip every run.
+      // body so health doesn't pull the multi-MB zip every run. Bounded by an
+      // abort deadline so a hung endpoint can't stall the whole health sweep.
       const res = await b
         .evalValue<{ status: number; ct: string; err?: string }>(
           `(async () => {
+            const ctrl = new AbortController();
+            const to = setTimeout(() => ctrl.abort(), 15000);
             try {
-              const r = await fetch('/design/v1/design/projects/' + ${JSON.stringify(projectId)} + '/download', { headers: { Accept: '*/*' } });
+              const r = await fetch('/design/v1/design/projects/' + ${JSON.stringify(projectId)} + '/download', { headers: { Accept: '*/*' }, signal: ctrl.signal });
               const o = { status: r.status, ct: r.headers.get('content-type') || '' };
               try { await r.body.cancel(); } catch {}
               return o;
             } catch (e) { return { status: 0, ct: '', err: String((e && e.message) || e) }; }
+            finally { clearTimeout(to); }
           })()`
         )
         .catch(() => ({ status: 0, ct: '', err: 'eval failed' }));
-      const ok = res.status === 200 && /zip/i.test(res.ct);
+      // Accept zip OR octet-stream: _downloadProjectZip validates by PK magic and
+      // ignores content-type, so a 200 octet-stream is a real success — don't go
+      // red where the download would succeed (the inverse of the old false-pass).
+      const ok = res.status === 200 && /(zip|octet-stream)/i.test(res.ct);
       return {
         ok,
         detail: ok ? `200 ${res.ct}` : `download endpoint status=${res.status} ct=${res.ct}${res.err ? ' err=' + res.err : ''}`


### PR DESCRIPTION
## Summary

`designer handoff` was broken by the **2026-06-21 claude.ai/design Share redesign**: it clicked a "Handoff to Claude Code" button and scraped a public `api.anthropic.com/v1/design/h/<id>` tar.gz URL — both **gone**. It now throws `button not found: handoff to claude code`. (Surfaced by the post-merge e2e on #77; the `share.handoffMenuItem` health anchor *false-passed* and hid it.)

**Root of the fix:** the new "Download" is an **authenticated same-origin GET** — `/design/v1/design/projects/<id>/download → application/zip`. The browser wraps it in a blob (needing a trusted gesture CDP can't fire), but the bytes come from a plain GET. So `handoff` fetches it **in-page** (auth + Cloudflare just work there; a node fetch with copied cookies `403`s) and transfers the bytes out as base64. **No download gesture, no `~/Downloads` watching — fully autonomous**, recovering the old "fetch a URL" model.

## Changes
- **`_downloadProjectZip`** — in-page authed fetch + base64 transfer + zip validation (magic `PK`), with an **origin guard** that refuses to fetch if the bound tab drifted off claude.ai (tab drift is real — it bit this session, the inbox's #10).
- **`handoff()`** — project id from the stored `designUrl`; unzips the **flat** export into `project/`; **regenerates `decision-record.md` from the live chat** (the export zip no longer ships the README/transcript the old tar.gz did). `HandoffResult` reshaped: `projectId`/`projectUrl`/`projectDir`/`decisionRecord*`/`zip*` (dropped `handoffUrl`/`tarball*`/`readme*`).
- **`tasting`** — consume the new flat `handoff-<ts>/project/` layout.
- **`share.handoffMenuItem` anchor** — probe the real endpoint (`200` + `application/zip`) instead of asserting "claude code" text exists (the old check false-passed: green while `handoff` threw). Id kept to preserve the health streak.
- **Docs** — `mcp-server` tool desc + CLI `HELP.handoff`.

## Verification (live, Chrome 149)
- `designer handoff` → **2,468,878-byte zip**, **64-file `project/` bundle** (HTML/CSS/JS + **38 screenshots**) + **10.5 KB `decision-record.md`**.
- Cold endpoint GET returns `200 application/zip` reliably (3/3) on the design tab.
- `designer tasting` renders the new bundle; `designer health` `share.handoffMenuItem` → `200 application/zip`; **15 ok / 0 fail**.
- `tsc` clean · **61 tests** green.

## Notes
- Considered but rejected: the **MCP-connector pivot** (upstream's new primary) — it drops the local file bundle that `tasting`/`/build`/`/acceptance` consume; deferrable to a future `designer handoff --mcp`. And the **download-gesture / `~/Downloads`-watch** approach — a probe gate proved CDP can't fire the download; the in-page fetch is simpler and autonomous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)