### PR TITLE
fix(detection): recognize signed-in redesigned /design home via account-menu anchor

### DIFF
--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -351,12 +351,15 @@ export class DesignerController {
     fidelity: 'wireframe' | 'highfi' = 'wireframe',
     { timeoutMs = 20 * 60_000, stabilityMs = 4000 }: { timeoutMs?: number; stabilityMs?: number } = {}
   ): Promise<{ ok: true; url: string; name: string; fidelity: string }> {
-    // 2026-06 redesign (#61): the home is composer-driven. There's no longer a
-    // project-name input or a wireframe/high-fi toggle — you seed an intent in
-    // the chat composer (`home.creator`, the same data-testid as the in-session
-    // composer) and click "Start project" (`home.createButton`, the same
-    // data-testid as the in-session send button). So `name` becomes the seed
-    // prompt. The redesign removed the wireframe/high-fi toggle, so `fidelity` is
+    // 2026-06 redesign (#61), re-captured 2026-06-30 (#73): the home is
+    // composer-driven. There's no longer a project-name input or a
+    // wireframe/high-fi toggle — you seed an intent in the home composer
+    // (`home.creator`, now the page's sole bare <textarea>; the home dropped all
+    // data-testids) and click "Create" (`home.createButton` = button[title=
+    // "Create"]). These are DISTINCT from the in-session composer/send testids,
+    // so _submitPrompt is given the home selectors explicitly below. `name`
+    // becomes the seed prompt. The redesign removed the wireframe/high-fi toggle,
+    // so `fidelity` is
     // folded into the seed as a directive (and still stored) — otherwise highfi
     // and wireframe creates would behave identically while the session claimed a
     // fidelity that was never applied (#66 review). The creation-type cards
@@ -400,9 +403,14 @@ export class DesignerController {
       : null;
     try {
       observer?.beginRun();
-      // Reuse the battle-tested composer fill+submit (contenteditable ProseMirror;
-      // waits for the send button to enable before clicking "Start project").
-      await this._submitPrompt(seed);
+      // Reuse the battle-tested composer fill+submit, but against the HOME
+      // selectors (sole <textarea> + button[title="Create"]) — the redesigned
+      // home no longer shares the in-session testids. The textarea branch of
+      // _submitPrompt fills it; it waits for "Create" to enable before clicking.
+      await this._submitPrompt(seed, {
+        composer: this.selectors.home.creator,
+        send: this.selectors.home.createButton
+      });
 
       let inSession = false;
       for (let i = 0; i < 60; i++) {
@@ -433,8 +441,13 @@ export class DesignerController {
     return { ok: true, url: stored.designUrl };
   }
 
-  async _submitPrompt(prompt: string): Promise<void> {
-    const { promptTextarea, sendButton } = this.selectors.composer;
+  // `sel` overrides the composer/send selectors for surfaces that don't use the
+  // in-session testids — notably the redesigned home, whose composer is a bare
+  // <textarea> and whose create button is button[title="Create"] (no data-testid;
+  // 2026-06-30 re-capture). Defaults to the in-session composer selectors.
+  async _submitPrompt(prompt: string, sel?: { composer?: string; send?: string }): Promise<void> {
+    const promptTextarea = sel?.composer ?? this.selectors.composer.promptTextarea;
+    const sendButton = sel?.send ?? this.selectors.composer.sendButton;
     await this.browser.waitFor(promptTextarea);
     // The composer has shipped as both a React-controlled <textarea> and a
     // ProseMirror contenteditable <div> — branch on what's actually there.

--- a/selectors.json
+++ b/selectors.json
@@ -1,19 +1,19 @@
 {
   "_notes": "Captured 2026-04-17 from Chrome 147 via CDP. Override at ~/.designer/selectors.override.json. Prefer data-testid over class names — Claude's styled-components classes (sc-xxx) are regenerated on every build.",
-  "_drift": "2026-06 (issue #61): the home was rebuilt around a composer. Captured live 2026-06-16 from Chrome 149 (signed-in profile). There is no project-name input or wireframe/high-fi toggle anymore — you seed an intent in the chat composer ([data-testid=chat-composer-input], the SAME element as the in-session composer) and click 'Start project' ([data-testid=chat-send-button], the same as the in-session send button). Creation-type cards (Start anywhere / Slides / Prototype / Product wireframe / Doc / Animation / Blank canvas) are text-only buttons with no data-testid; the default flow doesn't require clicking one. Projects render as <a href=/design/p/<uuid>> with the name as text (no project-card/projects-list testid). `designer adopt` remains available to bind an already-open tab to a key.",
+  "_drift": "2026-06-30 re-capture (Chrome 149, signed-in profile): the redesigned 'What will you design today?' home (issue #73 inbox) dropped ALL data-testids — the home renders ZERO [data-testid] nodes. The composer is now the page's sole bare <textarea> (its placeholder ROTATES — 'Drag in a PRD…', 'Make a pitch deck…', etc. — so do NOT anchor on placeholder text), and the create action is button[title=\"Create\"]. The signed-in app-shell marker is button[aria-label=\"Account menu\"] (the account avatar), present on BOTH the home and inside a session; the login wall renders neither it nor the composer. The IN-SESSION view is UNCHANGED — it still exposes [data-testid=chat-composer-input] (a contenteditable ProseMirror div), [data-testid=chat-send-button] (title='Send (Enter)'), chat-messages, html-viewer-iframe, etc. So home selectors and in-session selectors are DISTINCT again (the #61 'same testid on both surfaces' assumption no longer holds). Prior 2026-06 (#61) note: the home was first rebuilt around a composer that briefly shared the in-session testids; that build is gone. Creation-type cards (Prototype / Slides / Document / Wireframe / Animation / blank project) are text-only buttons with no data-testid; the default flow doesn't require clicking one. Projects render as <a href=/design/p/<uuid>> with the name as text (no project-card/projects-list testid). `designer adopt` remains the robust path around home-creation drift.",
   "_urls": {
     "home": "https://claude.ai/design",
     "session": "https://claude.ai/design/p/{uuid}"
   },
   "login": {
-    "signedInIndicator": "[data-testid=\"chat-composer-input\"]"
+    "signedInIndicator": "button[aria-label=\"Account menu\"], [data-testid=\"chat-composer-input\"]"
   },
   "home": {
-    "creator": "[data-testid=\"chat-composer-input\"]",
-    "nameInput": "[data-testid=\"chat-composer-input\"]",
-    "wireframeButtonText": "Product wireframe",
+    "creator": "textarea",
+    "nameInput": "textarea",
+    "wireframeButtonText": "Wireframe",
     "highFiButtonText": "Prototype",
-    "createButton": "[data-testid=\"chat-send-button\"]",
+    "createButton": "button[title=\"Create\"]",
     "projectsList": "a[href*=\"/design/p/\"]",
     "projectCard": "a[href*=\"/design/p/\"]"
   },

--- a/setup.ts
+++ b/setup.ts
@@ -35,17 +35,22 @@ async function isCdpUp(port: string): Promise<boolean> {
 }
 
 async function verifySignedIn(browser: Browser): Promise<boolean> {
-  // A signed-in claude.ai/design session renders one of these app-shell
-  // anchors — `project-creator` on the home surface, `chat-composer-input`
-  // inside a project. A logged-out visit to claude.ai/design renders a
-  // login wall with neither.
+  // A signed-in claude.ai/design session renders the account-menu avatar
+  // (aria-label="Account menu") on BOTH the home and inside a project; the
+  // in-session composer (chat-composer-input) is a second signed-in marker.
+  // A logged-out visit renders a login wall with neither.
+  //
+  // 2026-06-30 (#73): the redesigned home dropped ALL data-testids, so the old
+  // `project-creator`/`chat-composer-input` home markers vanished and this
+  // verifier false-failed for signed-in users. The account menu is the
+  // universal signed-in landmark now.
   //
   // This replaces the old URL-only check (URL matches /design && !/login/).
   // That check passed the login wall served AT the /design URL — the URL
   // stays `/design` when logged out, no `/login` substring — which is the
   // #16 false positive. The DOM is the only reliable signal.
   const js =
-    '!!(document.querySelector(\'[data-testid="project-creator"]\') || document.querySelector(\'[data-testid="chat-composer-input"]\'))';
+    '!!(document.querySelector(\'button[aria-label="Account menu"]\') || document.querySelector(\'[data-testid="chat-composer-input"]\'))';
   return browser.evalValue<boolean>(js).catch(() => false);
 }
 

--- a/tests/ui-drift.matchers.test.mjs
+++ b/tests/ui-drift.matchers.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import { isPreviewIframeSrc, previewIframeVariant } from '../preview-host.ts';
 import { SESSION_URL_RE } from '../designer-controller.ts';
+import { UI_ANCHORS } from '../ui-anchors.ts';
 
 // Regression coverage for the 2026-06 claude.ai/design entry-layer drift
 // (issue #61): the preview iframe moved off the signed `?t=` token onto a
@@ -52,4 +53,67 @@ test('SESSION_URL_RE rejects the home and non-design URLs', () => {
   assert.equal(SESSION_URL_RE.test('https://claude.ai/design/'), false);
   assert.equal(SESSION_URL_RE.test('https://claude.ai/chat/p/abc'), false);
   assert.equal(SESSION_URL_RE.test('https://example.com/design/p/abc'), false);
+});
+
+// Regression coverage for the 2026-06-30 signed-in detection drift (issue #73
+// inbox): the redesigned "What will you design today?" home dropped ALL
+// data-testids, so the old chat-composer-input signed-in marker false-failed as
+// "signed out" even for fully signed-in users. The fix re-anchors detection on
+// the account-menu avatar (present on home AND session) and teaches the health
+// probe to distinguish real selector drift from a genuine login wall.
+//
+// `evalValue(expr)` is the only browser method these anchor checks call; a stub
+// that decides truthiness from the evaluated expression text exercises them
+// without a live page.
+const anchor = (id) => {
+  const a = UI_ANCHORS.find((x) => x.id === id);
+  if (!a) throw new Error(`anchor not found: ${id}`);
+  return a;
+};
+const stubBrowser = (decide) => ({ evalValue: async (expr) => decide(expr) });
+
+test('login.signedIn: account-menu marker on a /design URL => signed in (home or session)', async () => {
+  const b = stubBrowser((expr) => expr.includes('Account menu'));
+  const r = await anchor('login.signedIn').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, true);
+});
+
+test('login.signedIn: marker missing but app shell rendering => SELECTOR DRIFT, not signed out', async () => {
+  // account-menu probe fails; the shell-present probe (textarea / project links /
+  // heading) succeeds — exactly the redesigned-home drift state.
+  const b = stubBrowser((expr) => !expr.includes('Account menu'));
+  const r = await anchor('login.signedIn').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, false);
+  assert.match(r.detail, /SELECTOR DRIFT/);
+  assert.doesNotMatch(r.detail, /designer setup/); // must NOT send the user to re-login
+});
+
+test('login.signedIn: no marker and no app shell => genuinely signed out', async () => {
+  const b = stubBrowser(() => false);
+  const r = await anchor('login.signedIn').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, false);
+  assert.match(r.detail, /signed out/);
+});
+
+test('login.signedIn: explicit /login URL => signed out without probing the DOM', async () => {
+  let touched = false;
+  const b = stubBrowser(() => {
+    touched = true;
+    return true;
+  });
+  const r = await anchor('login.signedIn').check(b, 'https://claude.ai/login?returnTo=%2Fdesign');
+  assert.equal(r.ok, false);
+  assert.equal(touched, false, 'URL login wall is decided without a DOM probe');
+});
+
+test('home.creator anchors the sole home <textarea> (home dropped all data-testids)', async () => {
+  const b = stubBrowser((expr) => expr.includes('textarea'));
+  const r = await anchor('home.creator').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, true);
+});
+
+test('home.createButton anchors button[title="Create"], not the in-session chat-send-button', async () => {
+  const b = stubBrowser((expr) => expr.includes('Create'));
+  const r = await anchor('home.createButton').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, true);
 });

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -170,14 +170,31 @@ export const UI_ANCHORS: AnchorDef[] = [
       if (/claude\.ai\/login/.test(url)) {
         return { ok: false, detail: `signed out — Chrome is on the login wall (${url.slice(0, 80)}). Run: designer setup` };
       }
-      // On a design surface, the signed-in app shell renders the chat composer
-      // (chat-composer-input) on BOTH the home (creation composer, post-2026-06
-      // redesign #61) and inside a session. Its absence here means the login
-      // wall is being served at the /design URL — fail loudly.
+      // On a design surface, the signed-in app shell renders the account-menu
+      // avatar (aria-label="Account menu") on BOTH the home and inside a session;
+      // the in-session composer (chat-composer-input) is a second signed-in
+      // marker. The login wall renders neither. (2026-06-30 #73: the redesigned
+      // home dropped ALL data-testids, so the old chat-composer-input home check
+      // false-failed as "signed out" — the inbox blocker. The account menu is the
+      // universal signed-in landmark now.)
       if (/claude\.ai\/design/.test(url)) {
-        const signedIn = await hasSelector(b, '[data-testid="chat-composer-input"]');
-        return signedIn
-          ? { ok: true }
+        const signedIn = await hasSelector(b, 'button[aria-label="Account menu"], [data-testid="chat-composer-input"]');
+        if (signedIn) return { ok: true };
+        // No signed-in marker. Before crying "signed out", check for any app-shell
+        // landmark (project links, the home composer textarea, the home heading).
+        // If the shell IS rendering, this is SELECTOR DRIFT of the signed-in
+        // marker — not a login wall — and telling the user to re-login is the
+        // fruitless dead end the 2026-06-29 inbox called out. Say "drift" instead.
+        const shellPresent = await b
+          .evalValue<boolean>(
+            `!!(document.querySelector('a[href*="/design/p/"]') || document.querySelector('textarea') || /what will you design today/i.test(document.body ? document.body.innerText : ''))`
+          )
+          .catch(() => false);
+        return shellPresent
+          ? {
+              ok: false,
+              detail: `app shell IS rendering at ${url.slice(0, 80)} but the signed-in marker (account menu) is missing — likely SELECTOR DRIFT, not signed out. Re-capture login.signedInIndicator; do NOT re-login.`
+            }
           : { ok: false, detail: `login wall rendered at ${url.slice(0, 80)} (no app shell) — signed out. Run: designer setup` };
       }
       // Off the claude.ai/design surface entirely (e.g. an unrelated tab) —
@@ -187,26 +204,26 @@ export const UI_ANCHORS: AnchorDef[] = [
   },
 
   // --- home page ---
-  // 2026-06 redesign (#61): the home is composer-driven — no project-name input
-  // and no wireframe/high-fi toggle. Creation = seed the chat composer
-  // (chat-composer-input) + click "Start project" (chat-send-button, same
-  // testids as the in-session composer/send). The old home.nameInput anchor was
-  // dropped (no equivalent); home.wireframeButton/highFiButton are repurposed to
-  // the surviving creation-type cards (text-only buttons) so they still detect
-  // drift of the creation UI. Captured live from Chrome 149.
+  // 2026-06 redesign (#61), re-captured 2026-06-30 (#73): the home is
+  // composer-driven AND has dropped ALL data-testids. Creation = fill the
+  // composer (now the page's sole bare <textarea> — its placeholder rotates, so
+  // it can't be anchored on placeholder text) + click "Create" (button[title=
+  // "Create"], NOT the in-session chat-send-button). home.wireframeButton/
+  // highFiButton track the surviving creation-type cards (text-only buttons) so
+  // they still detect drift of the creation UI. Captured live from Chrome 149.
   {
     id: 'home.creator',
     category: 'home',
-    description: 'creation composer (chat-composer-input)',
+    description: 'creation composer (sole home <textarea>; home dropped all data-testids)',
     requires: 'home',
-    check: async (b) => ({ ok: await hasSelector(b, '[data-testid="chat-composer-input"]') })
+    check: async (b) => ({ ok: await hasSelector(b, 'textarea') })
   },
   {
     id: 'home.wireframeButton',
     category: 'home',
-    description: 'Product wireframe creation-type card',
+    description: 'Wireframe creation-type card',
     requires: 'home',
-    check: async (b) => ({ ok: await hasButtonMatching(b, /^Product wireframe/) })
+    check: async (b) => ({ ok: await hasButtonMatching(b, /^Wireframe/) })
   },
   {
     id: 'home.highFiButton',
@@ -218,9 +235,9 @@ export const UI_ANCHORS: AnchorDef[] = [
   {
     id: 'home.createButton',
     category: 'home',
-    description: '"Start project" create button (chat-send-button)',
+    description: '"Create" project button (button[title="Create"])',
     requires: 'home',
-    check: async (b) => ({ ok: await hasSelector(b, '[data-testid="chat-send-button"], button[title^="Send ("]') })
+    check: async (b) => ({ ok: await hasSelector(b, 'button[title="Create"]') })
   },
   {
     id: 'home.projectsList',


### PR DESCRIPTION
## What & why

The redesigned **"What will you design today?"** claude.ai/design home **dropped every `data-testid`**. Designer's signed-in check keyed off `[data-testid="chat-composer-input"]`, which now exists **only inside a session** — so a fully signed-in user reading the home was detected as *signed out* and `designer session --action ensure_ready` threw `"Not signed in…"`. That killed the fract-ai `/designer-loop` (reported in `.inbox/2026-06-29-signed-in-detection-selector-drift.md`, #73).

It was **selector drift, not auth** — confirmed by probing the live signed-in DOM over CDP.

## The fix

- **Signed-in detection** re-anchored on `button[aria-label="Account menu"]` — the account avatar, present on **both** the home and inside a session, absent on the login wall. Applied in three places that all hardcoded the old marker:
  - `selectors.json` → `login.signedInIndicator`
  - `ui-anchors.ts` → `login.signedIn` health anchor
  - `setup.ts` → `verifySignedIn` (the `designer setup`/`doctor` verifier)
- **Home create-flow anchors** refreshed for the de-testid'd home: composer → the page's sole `<textarea>` (its placeholder **rotates**, so it can't be anchored on placeholder text), create → `button[title="Create"]`, card text "Product wireframe" → "Wireframe". `createSession` now hands `_submitPrompt` the home selectors explicitly (in-session path untouched).
- **Self-diagnosing health**: when the signed-in marker is missing *but the app shell is still rendering* (project links / composer / heading), `designer health` now reports **"likely SELECTOR DRIFT, not signed out — do NOT re-login"** instead of misdirecting the user to re-auth (inbox proposal #3).
- **Regression tests** in `tests/ui-drift.matchers.test.mjs` (stub-browser exercises of `login.signedIn` + the home anchors).

## Key finding: home vs session diverged again

The in-session view is **unchanged** — it still exposes `chat-composer-input` (contenteditable ProseMirror), `chat-send-button` (`title="Send (Enter)"`), `chat-messages`, `html-viewer-iframe`. Only the **home** lost its testids, so home and in-session selectors are **distinct** again (the #61 "same testid on both surfaces" assumption no longer holds).

## Verification (live, signed-in profile)

- `designer health` → **8 ok, 0 fail** on the home (was 2 ok / 7 fail)
- `designer session --action ensure_ready` → `{ ok: true }` (was throwing)
- `designer doctor` → `✓ signed in to claude.ai/design`
- `npm run check` clean · `npm test` 50/50

Verified the create path by filling the home composer and confirming the Create button enables, then clearing it — no throwaway project minted, user's tabs untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)