### PR TITLE
fix(health): distinguish signed-in marker drift from a genuine login wall

### DIFF
--- a/skills/designer-loop/SKILL.md
+++ b/skills/designer-loop/SKILL.md
@@ -86,6 +86,7 @@ Do not:
 - **Ask for tweaks** on the dimensions you expect to iterate (type, spacing, palette). Claude wires live sliders.
 - **Quantities help.** "N variations", "N loaders on a grid", "N-screen onboarding."
 - **Flat file layout for multi-file variants.** Tell Claude "all files at project root, no subfolders." Claude tends to organize variants under a folder (`directions/`, `variants/`) which the current MCP's file list doesn't see through — use the handoff bundle if you need nested layouts.
+- **Pre-empt the clarifying-questions flow; don't lean on it.** A decision-bearing prompt (scope and constraints pinned up front) leaves Claude nothing to ask, so the "Claude has some questions →" popover never appears. If it punts anyway — surfaced as `awaitingClarification` — answer by re-prompting with the missing specifics, or send `decisive: true` (which tells Claude to choose the most defensible answer and proceed). Do **not** expect designer to read or click that popover: it's ephemeral with no stable DOM contract, so designer deliberately won't scrape or auto-answer it. Deciding the requirement stays with you, the human designer.
 
 ### Picking the right artifact shape
 

--- a/tests/ui-drift.matchers.test.mjs
+++ b/tests/ui-drift.matchers.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import { isPreviewIframeSrc, previewIframeVariant, isBootstrapShellHtml } from '../preview-host.ts';
 import { SESSION_URL_RE } from '../designer-controller.ts';
+import { UI_ANCHORS } from '../ui-anchors.ts';
 
 // Regression coverage for the 2026-06 claude.ai/design entry-layer drift
 // (issue #61): the preview iframe moved off the signed `?t=` token onto a
@@ -74,4 +75,52 @@ test('SESSION_URL_RE rejects the home and non-design URLs', () => {
   assert.equal(SESSION_URL_RE.test('https://claude.ai/design/'), false);
   assert.equal(SESSION_URL_RE.test('https://claude.ai/chat/p/abc'), false);
   assert.equal(SESSION_URL_RE.test('https://example.com/design/p/abc'), false);
+});
+
+// login.signedIn health diagnostic (inbox #73 proposal #3): when the signed-in
+// marker is missing but the app shell IS rendering, the probe must say "selector
+// DRIFT, not signed out" rather than sending the user to re-login — the dead end
+// the fract-ai report hit on a stale build. The verdict stays `fail` either way;
+// only the guidance changes. `evalValue(expr)` is the sole browser call these
+// checks make, so a stub that decides from the evaluated expression exercises
+// them without a live page.
+const anchor = (id) => {
+  const a = UI_ANCHORS.find((x) => x.id === id);
+  if (!a) throw new Error(`anchor not found: ${id}`);
+  return a;
+};
+const stubBrowser = (decide) => ({ evalValue: async (expr) => decide(expr) });
+
+test('login.signedIn: signed-in marker present on /design => ok', async () => {
+  // The marker probe (signedInIndicator) matches; shell probe never reached.
+  const b = stubBrowser((expr) => /chat-composer-input|title="Create"/.test(expr));
+  const r = await anchor('login.signedIn').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, true);
+});
+
+test('login.signedIn: marker missing but app shell rendering => SELECTOR DRIFT, not signed out', async () => {
+  // Marker probe fails; the shell probe (project link / home heading) succeeds.
+  const b = stubBrowser((expr) => /what will you design|design\/p\//.test(expr));
+  const r = await anchor('login.signedIn').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, false);
+  assert.match(r.detail, /SELECTOR DRIFT/);
+  assert.doesNotMatch(r.detail, /designer setup/); // must NOT send the user to re-login
+});
+
+test('login.signedIn: marker missing and no app shell => genuinely signed out', async () => {
+  const b = stubBrowser(() => false);
+  const r = await anchor('login.signedIn').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, false);
+  assert.match(r.detail, /signed out/);
+});
+
+test('login.signedIn: explicit /login URL => signed out without probing the DOM', async () => {
+  let touched = false;
+  const b = stubBrowser(() => {
+    touched = true;
+    return true;
+  });
+  const r = await anchor('login.signedIn').check(b, 'https://claude.ai/login?returnTo=%2Fdesign');
+  assert.equal(r.ok, false);
+  assert.equal(touched, false, 'URL login wall is decided without a DOM probe');
 });

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -207,8 +207,31 @@ export const UI_ANCHORS: AnchorDef[] = [
       // absence means the login wall is served at the /design URL — fail loudly.
       if (/claude\.ai\/design/.test(url)) {
         const signedIn = await hasSelector(b, SEL.login.signedInIndicator ?? '');
-        return signedIn
-          ? { ok: true }
+        if (signedIn) return { ok: true };
+        // The signed-in marker is absent. Before reporting "signed out" (which
+        // sends the user to re-login), check for an unambiguous signed-in-home
+        // landmark the login wall never renders — a project link or the home
+        // heading. If one is present, the app shell IS up and the MARKER has
+        // drifted, not the session: say so, so the fix is "re-capture
+        // login.signedInIndicator", not a fruitless re-login. This is the
+        // self-diagnosis the 2026-06-29 inbox (#73) asked for, after a prior home
+        // redesign sent the reporter chasing a non-existent auth problem.
+        //
+        // Deliberately NOT keyed on a bare <textarea> (unlike the create-flow
+        // anchors): a re-auth/login page can render a textarea, and this arm must
+        // not call a genuine login wall "drift". Project links and the home
+        // heading only render for a signed-in home — the same anti-false-positive
+        // stance the signed-in arm takes by keying on the Create button.
+        const shellPresent = await b
+          .evalValue<boolean>(
+            `!!(document.querySelector('a[href*="/design/p/"]') || /what will you design today/i.test(document.body ? document.body.innerText : ''))`
+          )
+          .catch(() => false);
+        return shellPresent
+          ? {
+              ok: false,
+              detail: `app shell IS rendering at ${url.slice(0, 80)} but the signed-in marker (${SEL.login.signedInIndicator}) is missing — likely SELECTOR DRIFT, not signed out. Re-capture login.signedInIndicator in selectors.json; do NOT re-login.`
+            }
           : { ok: false, detail: `login wall rendered at ${url.slice(0, 80)} (no app shell) — signed out. Run: designer setup` };
       }
       // Off the claude.ai/design surface entirely (e.g. an unrelated tab) —


### PR DESCRIPTION
## What & why

`login.signedIn` (the health/`ensure_ready` signed-in probe) reported **"signed out — Run: designer setup"** whenever `login.signedInIndicator` was absent on a `/design` URL — even when the app shell *was* rendering and only the **marker** had drifted. That's the dead end the fract-ai report hit: a fully signed-in user on a redesigned home gets told to re-login, which does nothing (the loop stays parked).

This is **inbox proposal #3** from `.inbox/2026-06-29-signed-in-detection-selector-drift.md` (#73). The underlying selector drift was already fixed in **0.3.16** (`8c55d4c` + `b39737b`); this adds the *diagnostic* so the **next** drift self-identifies instead of masquerading as an auth problem.

## Change

In `login.signedIn`, when the marker probe fails on `/design`, run a second probe for an **unambiguous signed-in-home landmark** the login wall never renders — a `/design/p/` project link or the `"What will you design today?"` heading:

- **shell present** → `fail` with *"app shell IS rendering … the signed-in marker is missing — likely **SELECTOR DRIFT**, not signed out. Re-capture login.signedInIndicator; do NOT re-login."*
- **shell absent** → unchanged: *"login wall rendered … signed out. Run: designer setup."*

The **verdict stays `fail`** either way — only the guidance changes. Deliberately **not** keyed on a bare `<textarea>`: a re-auth page can render one, and this arm must never call a genuine login wall "drift" — the same anti-false-positive stance the signed-in arm already takes by keying on `button[title="Create"]`.

## Tests

4 regression tests for the four `login.signedIn` branches (signed-in, drift, signed-out, explicit `/login`), via a stub browser that decides from the evaluated expression. `tsc` clean · `npm test` **69/69**.

## Verification

Live happy path intact on a signed-in profile: `designer health` → `login.signedIn ✓`. The drift branch only fires when the marker is absent (unreproducible live without removing the marker), so it's covered by the unit tests.

> Note: branched from current `main` (0.3.16). An earlier PR (#95) for this report was closed as redundant — it was authored against a stale local `main` and duplicated the already-shipped 0.3.16 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Also in this PR (follow-up decision):** `docs(designer-loop)` captures that designer should *not* learn to read or click the ephemeral "Claude has some questions →" popover — it has no stable DOM contract, and auto-answering would put the AI in the human designer's seat. The guidance: front-load decision-bearing detail or use `decisive: true`; `awaitingClarification` stays as the soft backstop.
