### PR TITLE
fix(nav,oopif): bound the beforeunload accepter, scope to exact tab, prefer freshest preview

### DIFF
--- a/cdp-dialog.ts
+++ b/cdp-dialog.ts
@@ -31,6 +31,19 @@ export function shouldAcceptBeforeUnload(method: string, params: unknown): boole
   return asRec(params).type === 'beforeunload';
 }
 
+// Bound a CDP call so a live-but-silent socket can't hang the guard. The base
+// CdpSession.send() has no timeout (only the WS *open* is bounded), so a wedged
+// Chrome that never answers Page.enable would otherwise hang attach() BEFORE the
+// navigation even starts — strictly worse than a plain open() (second-opinion
+// 2026-06-30, H3). Reject on timeout so attach()'s catch degrades to no-guard.
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
+}
+
 export class BeforeUnloadAccepter extends CdpSession {
   private accepted = 0;
 
@@ -43,16 +56,23 @@ export class BeforeUnloadAccepter extends CdpSession {
 
   static async attach(opts: CdpSessionOptions = {}): Promise<BeforeUnloadAccepter | null> {
     if (typeof WebSocket === 'undefined') return null;
+    let accepter: BeforeUnloadAccepter | null = null;
     try {
-      // tolerateDuplicateUrl: a duplicate tab at the same URL must not throw — the
-      // guard is best-effort; a wrong/failed pick simply means the navigation isn't
-      // guarded (degrades to the prior behavior), never a crash.
-      const resolved: CdpSessionOptions = { tolerateDuplicateUrl: true, ...opts };
+      // tolerateDuplicateUrl DEFAULTS FALSE here (unlike the read-only OOPIF
+      // reader): for a dialog accepter, a WRONG-tab pick is materially worse than
+      // no guard — it would arm auto-accept on an unrelated tab AND miss the real
+      // dialog (second-opinion 2026-06-30, H3). On a duplicate-URL ambiguity,
+      // connectTarget throws -> we degrade to no-guard (a plain open), never an
+      // arbitrary tab. Callers can still override.
+      const resolved: CdpSessionOptions = { tolerateDuplicateUrl: false, ...opts };
       const { ws, target } = await BeforeUnloadAccepter.connectTarget(resolved);
-      const accepter = new BeforeUnloadAccepter(ws, target, resolved);
+      accepter = new BeforeUnloadAccepter(ws, target, resolved);
       await accepter.start();
       return accepter;
     } catch {
+      // Close the socket if start() (the bounded Page.enable) failed/timed out, so
+      // a failed attach can't leak a half-open Page-enabled client on a tab.
+      accepter?.close();
       return null;
     }
   }
@@ -62,8 +82,10 @@ export class BeforeUnloadAccepter extends CdpSession {
   }
 
   // Only Page is needed; skip the base's Network buffering for a one-shot guard.
+  // Bounded so a wedged-but-open socket degrades to no-guard instead of hanging
+  // the navigation before it starts (second-opinion 2026-06-30, H3).
   protected override async enableDomains(): Promise<void> {
-    await this.send('Page.enable');
+    await withTimeout(this.send('Page.enable'), 2000, 'Page.enable');
   }
 
   // Count of dialogs auto-accepted this session (diagnostic / test signal).

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -152,17 +152,32 @@ export class DesignerController {
   // prior behavior, never worse. We bind it to the CURRENT tab (the one about to
   // be navigated, which is the one that holds the dirty canvas).
   private async openGuarded(url: string): Promise<void> {
-    if (!isCdpEnabled()) {
+    // Only guard when we can bind the accepter to a DEFINITE single design tab —
+    // the one about to be navigated. With CDP off, an unknown current URL, or a
+    // non-design tab, attaching with a null/loose prefix could land on an arbitrary
+    // tab and arm auto-accept there (second-opinion 2026-06-30, H3). In those cases
+    // just open plainly: no dirty design canvas is at risk anyway.
+    const cur = await this.currentUrl();
+    if (!isCdpEnabled() || !/claude\.ai\/design/.test(cur)) {
       await this.browser.open(url);
       return;
     }
-    const cur = await this.currentUrl();
-    const accepter = await BeforeUnloadAccepter.attach({
-      preferUrlPrefix: cur && /claude\.ai\/design/.test(cur) ? cur : null
-    }).catch(() => null);
+    // Exact-URL match + the accepter's tolerateDuplicateUrl:false default: if
+    // duplicate tabs make the target ambiguous, attach returns null and we degrade
+    // to a plain open rather than guess the wrong tab. attach is internally bounded
+    // (Page.enable can't hang it), so this can never wedge before browser.open.
+    const accepter = await BeforeUnloadAccepter.attach({ preferUrlPrefix: cur }).catch(() => null);
     try {
       await this.browser.open(url);
     } finally {
+      // Telemetry: surface when we actually dismissed a "Leave site?" modal, since
+      // accept discards the canvas's dirty state — make the (rare) destructive
+      // moment observable rather than silent.
+      if (accepter && accepter.acceptedCount > 0) {
+        console.warn(
+          `[designer] auto-dismissed ${accepter.acceptedCount} "Leave site?" dialog(s) navigating ${cur.slice(0, 60)} -> ${url.slice(0, 60)}`
+        );
+      }
       accepter?.close();
     }
   }

--- a/oopif-reader.ts
+++ b/oopif-reader.ts
@@ -94,15 +94,22 @@ function pickPreviewChild(children: AttachedChild[], isPreviewUrl: (u: string) =
   if (previews.length === 0) return null;
   if (previews.length === 1) return previews[0] ?? null;
   // Multiple preview OOPIFs. A design-canvas (`.dc.html`) file renders TWO frames
-  // of the SAME file — a signed `?t=` token frame plus an `_omeo` frame, both
-  // identical rendered content (live-verified 2026-06-30; plain `.html` renders
-  // exactly one). Disambiguate by the per-file `/serve/<filename>` path: if every
-  // preview serves the SAME file they're duplicate renders, so pick one. Only a
-  // GENUINE ambiguity — frames for DIFFERENT files, e.g. old+new coexisting during
-  // a file switch — stays null, so we never serve a stale wrong-file frame as the
-  // requested file (the #67 invariant this guard was built to protect).
+  // of the SAME file — a signed `?t=` token frame plus an `_omeo` frame, ~identical
+  // rendered content (live-verified 2026-06-30; plain `.html` renders exactly one).
+  // Disambiguate by the per-file `/serve/<filename>` path: if every preview serves
+  // the SAME file they're duplicate renders, so pick one. Only a GENUINE ambiguity
+  // — frames for DIFFERENT files, e.g. old+new coexisting during a file switch —
+  // stays null, so we never serve a stale wrong-FILE frame (the #67 invariant).
+  //
+  // Among same-file duplicates pick the LAST attached, not the first: during a
+  // re-prompt/regeneration of the same file a fresh preview frame attaches after
+  // the stale one, so the freshest entry is the better bet for current content
+  // (second-opinion 2026-06-30, H1). This is a heuristic, not a freshness proof —
+  // same-file frames can't be byte-compared (their token/theme query is reflected
+  // in the HTML); the load-bearing guard against stale capture remains the
+  // caller's capture-after-generation-settles, not frame selection.
   const names = new Set(previews.map((c) => serveFileName(c.url)));
-  if (names.size === 1 && !names.has(null)) return previews[0] ?? null;
+  if (names.size === 1 && !names.has(null)) return previews[previews.length - 1] ?? null;
   return null;
 }
 

--- a/tests/cdp-trace.oopif.test.mjs
+++ b/tests/cdp-trace.oopif.test.mjs
@@ -100,18 +100,22 @@ test('STRICT: multiple preview children for DIFFERENT files (old+new mid-switch)
   assert.equal(html, null, 'distinct serve filenames cannot be disambiguated -> null, not an arbitrary/stale frame');
 });
 
-test('DC DUAL-FRAME: two preview children for the SAME file (.dc.html token + _omeo frames) -> read one', async () => {
+test('DC DUAL-FRAME: two preview children for the SAME file (.dc.html token + _omeo frames) -> read the FRESHEST', async () => {
   // A .dc.html canvas renders the SAME file in two OOPIFs differing only in query
-  // (a signed ?t= token frame and an _omeo frame), both identical content. The
-  // old strict uniqueness floored this to null -> empty snapshot/iterate capture
-  // (live regression 2026-06-30). Same /serve/<filename> => duplicate renders =>
-  // pick one and read it, rather than bail.
+  // (a signed ?t= token frame and an _omeo frame). The old strict uniqueness
+  // floored this to null -> empty snapshot/iterate capture (live regression
+  // 2026-06-30). Same /serve/<filename> => duplicate renders => pick one. Among
+  // same-file dups pick the LAST attached (freshest) — during a re-prompt the new
+  // frame attaches after the stale one, so the freshest is the better bet for
+  // current content (second-opinion H1). childA attaches first (stale), the token
+  // frame second (fresh).
   const SRC_A_TOKEN = 'https://abc-uuid.claudeusercontent.com/v1/design/projects/abc-uuid/serve/a.html?t=tok.abc.123&srcmap=1';
-  const childAToken = { sessionId: 'sidAt', url: SRC_A_TOKEN, type: 'iframe' };
-  const send = fakeSend({ domHtml: { sidA: '<html><body>dc-A-marker</body></html>', sidAt: '<html><body>dc-A-marker</body></html>' } });
-  const html = await captureOopifHtml(send, { ...base, attachedTargets: () => [childA, childAToken], waitForAttachMs: 30 });
+  const childAFresh = { sessionId: 'sidAt', url: SRC_A_TOKEN, type: 'iframe' };
+  const send = fakeSend({ domHtml: { sidA: '<html><body>STALE-A</body></html>', sidAt: '<html><body>FRESH-A</body></html>' } });
+  const html = await captureOopifHtml(send, { ...base, attachedTargets: () => [childA, childAFresh], waitForAttachMs: 30 });
   assert.ok(html, 'two frames of the SAME file must read one, not null');
-  assert.ok(html.includes('dc-A-marker'), 'must return the file content, not the shell');
+  assert.ok(html.includes('FRESH-A'), 'must return the freshest (last-attached) same-file frame');
+  assert.ok(!html.includes('STALE-A'), 'must NOT return the stale (first-attached) same-file frame');
   assert.notEqual(html, SHELL);
 });
 


### PR DESCRIPTION
## What & why

Fix-forward on a **GPT-Pro second-opinion** of the 0.3.18 beforeunload/dual-frame work (dice-gate triggered). It found one real regression I'd shipped plus two sharpened risks; this addresses all three. Verified each claim against the code before acting.

### H3 — bound the accepter (regression fix)
`BeforeUnloadAccepter.start()` awaited an **unbounded** `Page.enable` (the base `send()` has no timeout — only the WS *open* was bounded). On a wedged-but-open CDP socket that would hang `openGuarded` **before** `browser.open` — strictly worse than the old direct open — and `.catch()` can't catch a hang. Now `Page.enable` is bounded (2s) → degrades to no-guard; the socket is closed if `start()` fails so a failed attach can't leak a Page-enabled client.

### H3 — scope to the exact tab (blast-radius fix)
A *wrong-tab* dialog accepter is worse than none (misses the real modal AND arms auto-accept on an unrelated tab). So: the accepter now defaults `tolerateDuplicateUrl=false` (ambiguous duplicates → no guard, never a guess), and `openGuarded` only arms when the current tab is a **definite** `claude.ai/design` URL (no null/loose-prefix arbitrary attach). It also **logs** when it actually dismisses a "Leave site?" modal — the destructive moment is now observable. Accept stays the default (product call).

### H1 — prefer the freshest preview frame
Among same-file duplicate OOPIFs, pick the **last attached** (freshest) instead of `previews[0]` — during a re-prompt the fresh frame attaches after the stale one. It's a heuristic, not a proof (same-file frames can't be byte-compared — their token/theme query is reflected in the HTML, so equality-gating would wrongly null the `.dc` case); the load-bearing guard against stale capture remains *capture-after-generation-settles*.

## Tests
`tsc` clean · `npm test` **74/74**. The DC dual-frame test now asserts the **freshest** frame is returned (STALE vs FRESH markers); the STRICT different-file → null invariant is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
