### PR TITLE
ci: run workflows on Node 22 (native WebSocket) — fixes the daily probe's chronic CDP false-drift

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Download health artifact from triggering run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci --no-audit --no-fund
       - run: npm run check
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - run: npm ci --no-audit --no-fund
       # install-smoke.sh runs npm pack (which triggers the prepack hook =

--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -56,10 +56,16 @@ jobs:
 
       # The runner already has a node, but pinning it here keeps the Mac mini's
       # global node version free to drift without breaking this job.
+      # MUST be >=22 (package.json engines): the in-process CDP readers
+      # (OopifHtmlReader / RunStateObserver) use the native global WebSocket, which
+      # only exists on Node >=22. On Node 20 `typeof WebSocket === 'undefined'`, so
+      # both attach() return null and every CDP anchor (session.oopifPreviewRead,
+      # network.turnRpcContract) false-fails "attach failed" — the chronic drift the
+      # probe kept filing. Do NOT drop below 22.
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install

--- a/.github/workflows/lockfile-refresh.yml
+++ b/.github/workflows/lockfile-refresh.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Refresh transitive deps

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-node@v6
         if: steps.release.outputs.release_created || inputs.publish-tag
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           # No registry-url: setup-node would write an .npmrc that references
           # $NODE_AUTH_TOKEN, and npm hard-fails on unset env vars in config.


### PR DESCRIPTION
## Root cause

The daily-health probe has been filing selector-drift PRs (#94, #102) for **weeks** flagging `session.oopifPreviewRead` ("OOPIF reader attach failed") and `network.turnRpcContract` ("CDP observer unavailable"). These are **not UI/selector drift** — they pass in live usage. The cause: every workflow pinned **`node-version: '20'`**, but `package.json` `engines` require **`>=22`**.

designer's in-process CDP readers (`OopifHtmlReader`, `RunStateObserver`) use the **native global `WebSocket`**, which only exists on Node ≥22. On Node 20, `typeof WebSocket === 'undefined'`, so both `attach()` short-circuit to `null` → the CDP anchors false-fail every run.

## Verification

Ran the **exact probe** (`npm run probe:health`, same canary) on the self-hosted Mac mini runner:
- **Node 20 (workflow):** `oopifPreviewRead` "attach failed", `turnRpcContract` "observer unavailable" — 2 fail.
- **Node 24:** **24 ok / 0 fail / 0 skip** — `oopifPreviewRead` reads 162 KB, `turnRpcContract` observer works (terminal=finished), `fileListScrape` finds files.

## Change

Bump all six workflow Node pins `20 → 22` (the engines floor). agent-browser-based CI/build/release survived on 20 only because the unit tests mock `WebSocket` — but running below the declared engine was wrong and masked this. Added a comment on the daily-health pin so it can't silently regress.

After merge, a manual `daily-health` run on Node 22 should go green and auto-close the stale drift PR #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)