### PR TITLE
ci(health): single-file canary so fileListScrape is deterministic

### DIFF
--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -100,17 +100,24 @@ jobs:
         # DESIGNER_PROBE_PROJECT_URL is the "canary" project for session-state
         # anchors. The probe opens it after the home-phase pass so session.*
         # / share.* anchors get exercised. It must be a project the user
-        # commits to keeping around (named "designer smoke test" today).
+        # commits to keeping around ("designer health canary" today).
+        #
+        # Keep the canary SINGLE-FILE. A multi-file project (the old "designer
+        # smoke test", 72e73856, had 4) puts its files behind a "N pages" switcher
+        # instead of a flat Design Files list, so session.fileListScrape's flat
+        # text-scrape intermittently finds 0 -> chronic false-drift (2026-06-30).
+        # A one-file project renders `index.html` as a scrapable text node with no
+        # switcher, so the anchor is deterministic.
         #
         # To swap canaries:
-        #   1. Create a fresh project on claude.ai/design with stable content.
-        #   2. Open one file in it so the htmlViewer anchor lands.
+        #   1. Create a fresh SINGLE-FILE project on claude.ai/design (one index.html).
+        #   2. Open that file so the htmlViewer / fileListScrape anchors land.
         #   3. Replace the URL below + commit + `gh workflow run daily-health.yml`
         #      to verify green before the next scheduled run.
         # If the canary 404s or vanishes mid-cycle, session anchors fail loudly
         # — that's the signal to swap.
         env:
-          DESIGNER_PROBE_PROJECT_URL: https://claude.ai/design/p/72e73856-7b63-4aed-b95a-caca5e3c0e05
+          DESIGNER_PROBE_PROJECT_URL: https://claude.ai/design/p/6c5115ec-b27c-46b8-a7d9-1b09df042eff
         run: npm run -s probe:health
         continue-on-error: true
 


### PR DESCRIPTION
After the Node-22 fix (#103) resolved the chronic CDP false-drift, one residual remained: `session.fileListScrape` "found 0 filenames".

**Cause:** the canary `72e73856` ("designer smoke test") has 4 files, which claude.ai puts behind a **"4 pages" switcher** rather than a flat Design Files list — so the anchor's flat text-scrape intermittently finds 0 (it passed a manual run, failed the workflow run).

**Fix:** point `DESIGNER_PROBE_PROJECT_URL` at a **single-file** project (`6c5115ec`, "designer health canary" — one `index.html`). It renders `index.html` as a scrapable text node with no switcher.

**Verified** on the Mac mini runner: `npm run probe:health` against the new canary is **24 ok / 0 fail / 0 skip** (vs 23 ok / 1 fail on the old 4-file canary). Comment updated to require the canary stay single-file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)