### PR TITLE
ci(health): probe-heartbeat staleness alarm + launcher flag consistency

### DIFF
--- a/.github/workflows/probe-heartbeat.yml
+++ b/.github/workflows/probe-heartbeat.yml
@@ -1,0 +1,70 @@
+name: probe-heartbeat
+
+# Dead-man's-switch for the daily-health probe.
+#
+# The daily-health job runs on a SELF-HOSTED Mac mini runner. If that box is down
+# (asleep, or awaiting a FileVault login after a power outage) or its runner is
+# offline, the probe simply never fires — a silent gap no other signal catches. And
+# if the probe's ENVIRONMENT is broken (debug Chrome down / Node < 22 / canary gone),
+# its preflight fails the job red. This workflow runs on a GitHub-HOSTED runner —
+# independent of the Mac mini — and FAILS (which emails the repo owner via the
+# default Actions failure notification) when the latest daily-health run is stale or
+# didn't conclude success.
+#
+# What it does NOT alert on: real claude.ai UI/selector drift. That leaves the
+# daily-health job green (the probe step is continue-on-error) and opens a
+# selectors-drift PR instead — a separate, intentional signal.
+
+on:
+  schedule:
+    - cron: '0 16 * * *' # 16:00 UTC — 2h after daily-health's 14:00 cron, so it has finished
+  workflow_dispatch:
+
+permissions:
+  actions: read
+
+concurrency:
+  group: probe-heartbeat
+  cancel-in-progress: false
+
+jobs:
+  heartbeat:
+    name: alert if the daily-health probe went stale or broke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check the latest daily-health run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          MAX_AGE_HOURS: '26' # daily cadence (24h) + ~2h grace
+        run: |
+          set -euo pipefail
+          runs=$(gh run list --repo "$REPO" --workflow=daily-health.yml --limit 1 \
+            --json createdAt,status,conclusion,url)
+          if [ "$(echo "$runs" | jq 'length')" -eq 0 ]; then
+            echo "::error::No daily-health runs found at all — the probe has never run."
+            exit 1
+          fi
+          status=$(echo "$runs" | jq -r '.[0].status')
+          conclusion=$(echo "$runs" | jq -r '.[0].conclusion')
+          created=$(echo "$runs" | jq -r '.[0].createdAt')
+          url=$(echo "$runs" | jq -r '.[0].url')
+          age_h=$(( ( $(date -u +%s) - $(date -u -d "$created" +%s) ) / 3600 ))
+          echo "latest daily-health: status=$status conclusion=$conclusion age=${age_h}h"
+          echo "  $url"
+
+          fail=0
+          if [ "$age_h" -gt "$MAX_AGE_HOURS" ]; then
+            echo "::error::daily-health hasn't run in ${age_h}h (> ${MAX_AGE_HOURS}h) — the probe may be dead: the self-hosted Mac mini runner is offline, or the box is down / awaiting a FileVault login after an outage."
+            fail=1
+          fi
+          if [ "$status" = "completed" ] && [ "$conclusion" != "success" ]; then
+            echo "::error::latest daily-health run concluded '$conclusion' — the probe ENVIRONMENT is broken (debug Chrome down / Node < 22 / canary project gone), NOT claude.ai UI drift. See: $url"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "heartbeat ok — daily-health ran ${age_h}h ago and concluded success."

--- a/scripts/designer-chrome.ps1
+++ b/scripts/designer-chrome.ps1
@@ -47,4 +47,7 @@ Write-Host "[designer-chrome] When done, leave this window open. The CDP server 
 & $Chrome `
   "--remote-debugging-port=$Port" `
   "--user-data-dir=$Profile" `
+  "--no-first-run" `
+  "--no-default-browser-check" `
+  "--disable-search-engine-choice-screen" `
   "https://claude.ai/design"

--- a/scripts/designer-chrome.sh
+++ b/scripts/designer-chrome.sh
@@ -35,4 +35,7 @@ echo "[designer-chrome] When done, leave this window open. The CDP server runs a
 exec "$CHROME" \
   --remote-debugging-port="$PORT" \
   --user-data-dir="$PROFILE" \
+  --no-first-run \
+  --no-default-browser-check \
+  --disable-search-engine-choice-screen \
   "https://claude.ai/design"


### PR DESCRIPTION
Closes the last availability gap after the Node-20 saga: **nothing alarmed if the daily probe stopped running.**

## `probe-heartbeat.yml` — dead-man's-switch
A scheduled workflow on `ubuntu-latest` (GitHub-hosted, **independent** of the self-hosted Mac mini) that runs 2h after daily-health's cron and **fails** — which emails the repo owner (default Actions failure notification) — when the latest `daily-health` run is:
- **stale** (`createdAt` > 26h → the probe didn't run: runner offline, or the box is down / awaiting a FileVault login after an outage), or
- **not success** (`conclusion != success` → the probe's preflight went red = broken *environment*: Chrome down / Node < 22 / canary gone).

It deliberately does **not** fire on real claude.ai UI drift — that keeps daily-health green (the probe step is `continue-on-error`) and opens a `selectors-drift` PR instead, a separate intentional signal. Uses only `GITHUB_TOKEN` + `gh`, `permissions: actions: read`.

## Launcher flag consistency
Adds `--no-first-run --no-default-browser-check --disable-search-engine-choice-screen` to `scripts/designer-chrome.{sh,ps1}` so the manual launcher matches `setup.ts`'s canonical flag set — and the new Mac mini **`com.pro-vi.designer-chrome`** LaunchAgent (versioned in `pro-vi/nas`, deployed + KeepAlive-verified tonight) uses the same set.

## Verification
- Part 1 (Chrome autostart) already deployed on the mini: LaunchAgent loaded, CDP up on :9222, KeepAlive relaunches Chrome on kill, signed in past Cloudflare.
- After merge: `gh workflow run probe-heartbeat.yml` (recent daily-health success exists → passes) and `gh workflow run daily-health.yml` (confirms the probe attaches to the launchd Chrome).

🤖 Generated with [Claude Code](https://claude.com/claude-code)