### PR TITLE
fix(selectors): re-capture drifted home anchors onto data-testids

### DIFF
--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -563,17 +563,20 @@ export class DesignerController {
     fidelity: 'wireframe' | 'highfi' = 'wireframe',
     { timeoutMs = 20 * 60_000, stabilityMs = 4000 }: { timeoutMs?: number; stabilityMs?: number } = {}
   ): Promise<{ ok: true; url: string; name: string; fidelity: string }> {
-    // 2026-06 home (#61, re-drifted — re-captured live 2026-06-22): the home is
-    // composer-driven, but the composer is now a plain <textarea> (`home.creator`,
-    // placeholder rotates) with a separate `button[title="Create"]` submit
-    // (`home.createButton`) — NOT the in-session contenteditable / chat-send-button
-    // (those testids were stripped from the home). So `name` becomes the seed
-    // prompt. The redesign removed the wireframe/high-fi toggle, so `fidelity` is
-    // folded into the seed as a directive (and still stored) — otherwise highfi
-    // and wireframe creates would behave identically while the session claimed a
-    // fidelity that was never applied (#66 review). The creation-type cards
-    // (Slides / Prototype / Wireframe / Animation) set the Template pill but are
-    // off the seed path. Verified live against the redesigned home.
+    // 2026-07 home (re-drifted again — re-captured live 2026-07-24, Chrome 150):
+    // the home is composer-driven, but the composer is no longer a <textarea> at
+    // all — it is a ProseMirror contenteditable div (`home.creator` =
+    // [data-testid="home-composer-input"]; placeholder rotates, never key on it)
+    // with a separate submit (`home.createButton` =
+    // [data-testid="home-composer-send"], same element as button[title="Create"]).
+    // _submitPrompt's contenteditable branch drives it. It is still NOT the
+    // in-session chat-composer-input / chat-send-button — those testids exist only
+    // in-session. So `name` becomes the seed prompt. The redesign removed the
+    // wireframe/high-fi toggle, so `fidelity` is folded into the seed as a
+    // directive (and still stored) — otherwise highfi and wireframe creates would
+    // behave identically while the session claimed a fidelity that was never
+    // applied (#66 review). The creation-type cards (carousel-type-*) set the
+    // Template pill but are off the seed path. Verified live against the home.
     //
     // `name` is the composer seed, so it must be non-empty — a whitespace-only
     // name leaves the send button disabled and would otherwise spin the full
@@ -617,10 +620,11 @@ export class DesignerController {
       : null;
     try {
       observer?.beginRun();
-      // Reuse the composer fill+submit, pointed at the HOME composer (<textarea> +
-      // "Create"), not the in-session defaults. Note button[title="Create"] is
-      // always enabled, so the enable-wait is a no-op here — the synchronous fill
-      // above is what guarantees the seed text is present before the click.
+      // Reuse the composer fill+submit, pointed at the HOME composer
+      // (contenteditable + "Create"), not the in-session defaults. Note the home
+      // Create button is always enabled, so the enable-wait is a no-op here — the
+      // synchronous fill above is what guarantees the seed text is present before
+      // the click.
       await this._submitPrompt(seed, {
         textarea: this.selectors.home.creator,
         sendButton: this.selectors.home.createButton
@@ -706,9 +710,8 @@ export class DesignerController {
     // is enabled AND the input holds the text we just wrote. In-session, "enabled"
     // already implies content (send disables when empty); but the home "Create"
     // button is always enabled, so the content check is what prevents firing an
-    // empty/wrong-target submit there (home.creator is the generic `textarea` —
-    // a stray earlier textarea, or a fill that didn't register, would otherwise
-    // submit blank and spin the navigation poll into a misleading timeout).
+    // empty submit there — a fill that didn't register would otherwise submit
+    // blank and spin the navigation poll into a misleading timeout.
     for (let i = 0; i < 30; i++) {
       await new Promise((r) => setTimeout(r, 150));
       const ready = await this.browser.evalValue<boolean>(
@@ -986,9 +989,16 @@ export class DesignerController {
     await this.browser.waitFor(this.selectors.home.projectsList).catch(() => null);
     const json = await this.browser.evalValue<Array<{ name: string | null; sub: string | null; url: string | null }>>(
       `(() => {
-        // 2026-06 redesign (#61): there's no project-card data-testid. Each
-        // project is an <a href="/design/p/<uuid>"> with the project name as its
-        // text; dedupe by uuid (a card can wrap more than one anchor).
+        // 2026-07 redesign: projects moved from a flat list of text-bearing links
+        // to a <section data-testid="projects-list"> of <tr data-testid=
+        // "project-row">. The row's <a href="/design/p/<uuid>"> is now an EMPTY
+        // overlay link — reading its text (what the 2026-06 scrape did) yields
+        // null for every project. The name now lives in the row's first cell, and
+        // is mirrored onto the anchor's aria-label. Resolve through all three, in
+        // most- to least-structured order, so this survives either layout:
+        // anchor text (old flat list) -> aria-label -> the row's first cell.
+        // Anchor-keyed, not row-keyed, because the href is the only place the
+        // uuid appears; dedupe by uuid (a row can wrap more than one anchor).
         const links = Array.from(document.querySelectorAll('a[href*="/design/p/"]'));
         const seen = new Set();
         const out = [];
@@ -997,7 +1007,13 @@ export class DesignerController {
           const m = href.match(/\\/design\\/p\\/([a-f0-9-]+)/i);
           if (!m || seen.has(m[1])) continue;
           seen.add(m[1]);
-          out.push({ name: (a.textContent || '').trim() || null, sub: null, url: href });
+          const row = a.closest('[data-testid="project-row"], tr');
+          const firstCell = row ? row.querySelector('td') : null;
+          const name =
+            (a.textContent || '').trim() ||
+            (a.getAttribute('aria-label') || '').trim() ||
+            (firstCell ? (firstCell.textContent || '').trim() : '');
+          out.push({ name: name || null, sub: null, url: href });
         }
         return out;
       })()`

--- a/selectors.json
+++ b/selectors.json
@@ -1,21 +1,21 @@
 {
   "_notes": "Captured 2026-04-17 from Chrome 147 via CDP. Override at ~/.designer/selectors.override.json. Prefer data-testid over class names — Claude's styled-components classes (sc-xxx) are regenerated on every build.",
-  "_drift": "2026-06 (issue #61) re-drifted, re-captured live 2026-06-22 from Chrome 149 (signed-in profile): the home is still composer-driven but the composer is now a plain <textarea> (placeholder ROTATES — 'Describe an app', 'Make a pitch deck', … — so never key a selector on placeholder text) with a separate submit button[title=\"Create\"]. The home no longer carries chat-composer-input / chat-send-button — those testids were stripped from the home surface and now exist only in-session. There is no project-name input or wireframe/high-fi toggle — you type an intent in the textarea and click Create. Creation-type cards are now labelled 'Prototype'/'Slides'/'Document'/'Wireframe'/'Animation' (the earlier 'Product prototype'/'Product wireframe' from auto-heal PR #75/#76 never matched reality); clicking one sets the Template pill but is off the create path, so wireframeButtonText/highFiButtonText are health-anchor drift sentinels only. Projects render as <a href=/design/p/<uuid>> with the name as text (no project-card/projects-list testid). `designer adopt` remains available to bind an already-open tab to a key.",
+  "_drift": "2026-07 re-drifted, re-captured live 2026-07-24 from Chrome 150 (signed-in profile). The home is STILL composer-driven, but every home selector that was keyed on a tag name or a visible label has moved onto a data-testid — so this capture keys on testids only. Changes vs the 2026-06 capture: (1) the composer is no longer a <textarea> at all — the home now renders ZERO textareas; it is a ProseMirror contenteditable <div data-testid=\"home-composer-input\">. _submitPrompt's contenteditable branch (synthetic paste) drives it. (2) The submit button gained data-testid=\"home-composer-send\"; it is the SAME element as button[title=\"Create\"], which is kept as a fallback. It is always enabled, so content — not enabled-ness — is the submit gate. (3) The creation-type cards moved to data-testid=\"carousel-type-<kind>\" and their LABELS churn independently ('Product prototype' → 'Prototype' → 'Mobile app design' across three captures) — key on the testid, never the label. The testids survived every rename. (4) Projects moved from a flat link list to a <section data-testid=\"projects-list\"> of <tr data-testid=\"project-row\">; the row's <a href=/design/p/<uuid>> is now an EMPTY overlay link — the name lives in the first <td> and on the anchor's aria-label, so listProjects must not read anchor text. Placeholder text still ROTATES ('Draft a one-page project brief', …) — never key a selector on it. `designer adopt` remains available to bind an already-open tab to a key.",
   "_urls": {
     "home": "https://claude.ai/design",
     "session": "https://claude.ai/design/p/{uuid}"
   },
   "login": {
-    "signedInIndicator": "[data-testid=\"chat-composer-input\"], button[title=\"Create\"]"
+    "signedInIndicator": "[data-testid=\"chat-composer-input\"], [data-testid=\"home-composer-input\"], button[title=\"Create\"]"
   },
   "home": {
-    "creator": "textarea",
-    "nameInput": "textarea",
-    "wireframeButtonText": "Wireframe",
-    "highFiButtonText": "Prototype",
-    "createButton": "button[title=\"Create\"]",
-    "projectsList": "a[href*=\"/design/p/\"]",
-    "projectCard": "a[href*=\"/design/p/\"]"
+    "creator": "[data-testid=\"home-composer-input\"]",
+    "nameInput": "[data-testid=\"home-composer-input\"]",
+    "wireframeButton": "[data-testid=\"carousel-type-wireframe\"]",
+    "highFiButton": "[data-testid=\"carousel-type-prototype\"]",
+    "createButton": "[data-testid=\"home-composer-send\"], button[title=\"Create\"]",
+    "projectsList": "[data-testid=\"projects-list\"], a[href*=\"/design/p/\"]",
+    "projectCard": "[data-testid=\"project-row\"], a[href*=\"/design/p/\"]"
   },
   "composer": {
     "promptTextarea": "[data-testid=\"chat-composer-input\"]",

--- a/selectors.ts
+++ b/selectors.ts
@@ -17,8 +17,12 @@ export interface Selectors {
   home: {
     creator: string;
     nameInput: string;
-    wireframeButtonText: string;
-    highFiButtonText: string;
+    // Creation-type cards, keyed by data-testid. These were `*ButtonText` label
+    // literals until 2026-07: the labels churned three times ("Product prototype"
+    // → "Prototype" → "Mobile app design") while the testids never moved, so the
+    // contract is a selector now, not text to match.
+    wireframeButton: string;
+    highFiButton: string;
     createButton: string;
     projectsList: string;
     projectCard: string;

--- a/tests/ui-drift.matchers.test.mjs
+++ b/tests/ui-drift.matchers.test.mjs
@@ -124,3 +124,44 @@ test('login.signedIn: explicit /login URL => signed out without probing the DOM'
   assert.equal(r.ok, false);
   assert.equal(touched, false, 'URL login wall is decided without a DOM probe');
 });
+
+// 2026-07 home drift (PRs #118-#126: nine consecutive daily drift reports).
+// Both regressions were anchors keyed on something cosmetic rather than on a
+// data-testid, so these lock in the testid contract:
+//   * home.creator was the bare tag `textarea`; the home now renders none.
+//   * home.highFiButton matched the visible label "Prototype", renamed to
+//     "Mobile app design" — the third rename of that card, while its
+//     `carousel-type-prototype` testid never moved once.
+// The stub decides from the evaluated expression, so asserting the probe fires
+// on the testid (and NOT on the tag/label) is exactly the regression guard.
+
+test('home.creator probes the composer testid, not a bare <textarea> tag', async () => {
+  const onTestid = stubBrowser((expr) => /home-composer-input/.test(expr));
+  assert.equal((await anchor('home.creator').check(onTestid, 'https://claude.ai/design')).ok, true);
+
+  // A page with textareas but no home-composer-input must NOT satisfy the anchor:
+  // that is the 2026-06 selector, and matching it would mask the drift.
+  const onTagOnly = stubBrowser((expr) => /'textarea'|"textarea"/.test(expr));
+  assert.equal((await anchor('home.creator').check(onTagOnly, 'https://claude.ai/design')).ok, false);
+});
+
+test('home creation-type cards probe carousel testids, so a label rename cannot break them', async () => {
+  for (const [id, testid] of [
+    ['home.highFiButton', 'carousel-type-prototype'],
+    ['home.wireframeButton', 'carousel-type-wireframe']
+  ]) {
+    const onTestid = stubBrowser((expr) => new RegExp(testid).test(expr));
+    assert.equal((await anchor(id).check(onTestid, 'https://claude.ai/design')).ok, true, `${id} matches ${testid}`);
+
+    // Labels churn independently of the testids — a probe that only sees the old
+    // visible text must fail, and one that only sees the NEW text must not be
+    // required either. Neither label is load-bearing.
+    const onLabelOnly = stubBrowser((expr) => /Prototype|Wireframe|Mobile app design/.test(expr));
+    assert.equal((await anchor(id).check(onLabelOnly, 'https://claude.ai/design')).ok, false, `${id} is not label-keyed`);
+  }
+});
+
+test('home.createButton tolerates both the testid and the legacy title="Create" form', async () => {
+  const onTestid = stubBrowser((expr) => /home-composer-send/.test(expr));
+  assert.equal((await anchor('home.createButton').check(onTestid, 'https://claude.ai/design')).ok, true);
+});

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -16,10 +16,6 @@ import { getSelectors } from './selectors.ts';
 // leave a stale health probe behind (the login.signedIn class of bug).
 const SEL = getSelectors();
 
-// Build a "button text starts with <literal>" matcher from a selectors.json
-// text value (the creation-card sentinels), escaping regex specials.
-const startsWithRegExp = (text: string): RegExp => new RegExp('^' + text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-
 export type AnchorCategory = 'home' | 'session' | 'share' | 'pattern';
 export type AnchorState = 'home' | 'session' | 'any';
 export type ProbeStatus = 'ok' | 'fail' | 'skip';
@@ -256,57 +252,57 @@ export const UI_ANCHORS: AnchorDef[] = [
   },
 
   // --- home page ---
-  // 2026-06 home (#61), re-captured live 2026-06-22: still composer-driven, but
-  // the composer is now a plain <textarea> (placeholder rotates — don't key on it)
-  // and the submit is button[title="Create"]. The home no longer carries
-  // chat-composer-input / chat-send-button — those testids were stripped from the
-  // home and exist only in-session. Creation = type intent in the textarea + click
-  // Create. The old home.nameInput anchor stays dropped (no equivalent);
-  // home.wireframeButton/highFiButton track the creation-type cards (now labelled
-  // "Wireframe"/"Prototype" — the earlier "Product …" labels never matched) so they
-  // still detect drift of the creation UI. Captured live from Chrome 149.
+  // 2026-07 home, re-captured live 2026-07-24 from Chrome 150 (signed-in profile)
+  // after nine consecutive daily drift PRs (#118–#126). Still composer-driven, but
+  // every home anchor is now keyed on a data-testid — the two that regressed were
+  // the two keyed on a tag name and a visible label:
+  //   * home.creator was the bare tag `textarea`; the home now renders ZERO
+  //     textareas (the composer is a ProseMirror contenteditable div).
+  //   * home.highFiButton matched the label "Prototype", which was renamed to
+  //     "Mobile app design" — the third rename of that card's label, against zero
+  //     moves of its `carousel-type-prototype` testid.
+  // So the creation-type cards are selector anchors now, not text matchers. The
+  // old home.nameInput anchor stays dropped (no equivalent). The cards remain off
+  // the create path (they only set the Template pill) — drift sentinels only.
   {
     id: 'home.creator',
     category: 'home',
-    description: 'creation composer (textarea)',
+    description: 'creation composer (contenteditable [data-testid="home-composer-input"])',
     requires: 'home',
     check: async (b) => ({ ok: await hasSelector(b, SEL.home.creator) })
   },
   {
     id: 'home.wireframeButton',
     category: 'home',
-    description: 'Wireframe creation-type card',
+    description: 'Wireframe creation-type card ([data-testid="carousel-type-wireframe"])',
     requires: 'home',
-    check: async (b) => ({ ok: await hasButtonMatching(b, startsWithRegExp(SEL.home.wireframeButtonText)) })
+    check: async (b) => ({ ok: await hasSelector(b, SEL.home.wireframeButton) })
   },
   {
     id: 'home.highFiButton',
     category: 'home',
-    // Card labelled just "Prototype" (the 2026-06-19 auto-heal PR #75/#76
-    // "Product prototype" rename never matched live). Off the create path — a
-    // drift sentinel only.
-    description: 'Prototype creation-type card',
+    description: 'Prototype creation-type card ([data-testid="carousel-type-prototype"])',
     requires: 'home',
-    check: async (b) => ({ ok: await hasButtonMatching(b, startsWithRegExp(SEL.home.highFiButtonText)) })
+    check: async (b) => ({ ok: await hasSelector(b, SEL.home.highFiButton) })
   },
   {
     id: 'home.createButton',
     category: 'home',
-    description: '"Create" submit button (button[title="Create"])',
+    description: 'creation submit button ([data-testid="home-composer-send"] / button[title="Create"])',
     requires: 'home',
     check: async (b) => ({ ok: await hasSelector(b, SEL.home.createButton) })
   },
   {
     id: 'home.projectsList',
     category: 'home',
-    description: 'project list (>=1 /design/p/ link)',
+    description: 'project list ([data-testid="projects-list"])',
     requires: 'home',
     check: async (b) => ({ ok: await hasSelector(b, SEL.home.projectsList) })
   },
   {
     id: 'home.projectCard',
     category: 'home',
-    description: 'project card (a[href*="/design/p/"])',
+    description: 'project row ([data-testid="project-row"])',
     requires: 'home',
     check: async (b) => ({ ok: await hasSelector(b, SEL.home.projectCard) })
   },


### PR DESCRIPTION
Closes the nine consecutive daily drift PRs: #118, #119, #120, #121, #122, #123, #124, #125, #126.

## What drifted

The daily health probe has failed since 2026-07-16. Two anchors regressed, and both were keyed on something cosmetic rather than on a `data-testid`:

| Anchor | Was | Live now (Chrome 150) |
| --- | --- | --- |
| `home.creator` | `textarea` | `[data-testid="home-composer-input"]` — a ProseMirror contenteditable; the home renders **zero** textareas |
| `home.highFiButton` | label text `"Prototype"` | `[data-testid="carousel-type-prototype"]`, label now `"Mobile app design"` |

`home.creator` was not just a failing probe — it was a **real functional break**. `createSession()` waits on that selector, so `designer session create` could not run at all against the current UI.

The `highFiButton` label has now been renamed three times (`"Product prototype"` → `"Prototype"` → `"Mobile app design"`) while its `carousel-type-prototype` testid never moved once. So the creation-type cards become selector anchors instead of text matchers. `home.wireframeButton` was passing purely by luck of an unchanged label; it moves to a testid too.

## A silent break the anchors never covered

Projects moved from a flat list of text-bearing links to a `[data-testid="projects-list"]` table of `[data-testid="project-row"]` rows. The row's `/design/p/<uuid>` anchor is now an **empty overlay link** — the name lives in the first `<td>` and on the anchor's `aria-label`.

`listProjects()` read that anchor's text, so **every project came back `name: null`**. The `home.projectCard` anchor only ever checked presence, so it stayed green through this. Name resolution now walks anchor text → `aria-label` → the row's first cell, which handles both layouts.

## Compatibility

`login.signedInIndicator`, `home.createButton`, `home.projectsList` and `home.projectCard` gain the new testids while keeping their previous forms as fallbacks, so this capture doesn't hard-cut the older UI. (`[data-testid="home-composer-send"]` is the same element as `button[title="Create"]`.)

## Verification

Live, end to end, against the signed-in designer profile on an alternate CDP port (`:9333`) — per the repo's "probe the live UI yourself" rule:

- All 8 home selectors resolve on the live page.
- The `listProjects` scrape, run exactly as the controller evaluates it: **20 projects, 0 null names** (all 20 were null before).
- The contenteditable fill path: ProseMirror intercepts the synthetic paste, text registers, submit enables.
- A throwaway project was created through the real composer fill+submit path, confirmed to navigate to `/design/p/<uuid>`, then **deleted** via Actions → Delete Project. Repo left clean; the user's `:9222` untouched.
- `npm run check` clean, `npm test` 77/77 pass.

Regression tests assert both anchors probe by testid and are **not** satisfied by the old tag/label, so the next label churn can't silently re-break them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
