### PR TITLE
fix(health): make the probe, healer, and scrape assert outcomes not activity

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -179,3 +179,17 @@ jobs:
             new selector matches the intended element before merging — auto-
             heal validates that the *anchor probes green*, not that the
             selector targets the *right* DOM node.
+
+      # Structural blindness is not a best-effort miss — it is a standing defect
+      # in auto-heal itself: anchors are failing and the patcher cannot express a
+      # fix for ANY of them, so no future run will resolve it either. The triage
+      # step emits an ::error annotation, but annotations do not change a step's
+      # outcome, so without this gate the workflow still concluded success in
+      # exactly the scenario this PR exists to stop reporting as green.
+      #
+      # Runs last so the label + drift-PR comment posted during triage land first.
+      - name: Fail when auto-heal is structurally blind
+        if: steps.triage.outputs.reason == 'blind-unpatchable'
+        run: |
+          echo "::error title=auto-heal cannot fix the failing anchors::${{ steps.triage.outputs.blind-anchors }} — these have failed for 2+ runs and none are auto-patchable. This will not resolve on its own; repair the selector by hand or extend the patcher."
+          exit 1

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -89,6 +89,10 @@ jobs:
             --color FFB4A2 \
             --description ">=5 anchors regressed at once — needs human triage" \
             2>/dev/null || true
+          gh label create auto-heal-blind \
+            --color D00000 \
+            --description "Anchors are failing but none are auto-patchable — auto-heal cannot fix these" \
+            2>/dev/null || true
 
       - name: Setup node
         uses: actions/setup-node@v6

--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -189,7 +189,11 @@ jobs:
       #
       # Runs last so the label + drift-PR comment posted during triage land first.
       - name: Fail when auto-heal is structurally blind
-        if: steps.triage.outputs.reason == 'blind-unpatchable'
+        # Gated on the dedicated `blind` output, not on `reason`: a wholesale
+        # regression that is ALSO unpatchable emits reason=wholesale-redesign,
+        # and keying on reason would miss exactly the worst case — many anchors
+        # down and auto-heal powerless to touch any of them.
+        if: steps.triage.outputs.blind == 'true'
         run: |
           echo "::error title=auto-heal cannot fix the failing anchors::${{ steps.triage.outputs.blind-anchors }} — these have failed for 2+ runs and none are auto-patchable. This will not resolve on its own; repair the selector by hand or extend the patcher."
           exit 1

--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -233,3 +233,19 @@ jobs:
         run: |
           echo "::error title=Health probe did not fully run::verdict=incomplete — the UI anchors may be green but the tooling half of the probe is broken. This is not selector drift; see the doctor block in artifact health-${{ github.run_id }}."
           exit 1
+
+      # Backstop: the probe emitted no recognizable verdict at all. Every exit
+      # path inside ci-health routes through exitWith(), so this should be
+      # unreachable — but a hard kill (OOM, runner timeout, SIGKILL) terminates
+      # the process before any output is written, and `continue-on-error: true`
+      # means an unset verdict would otherwise leave every gate above false and
+      # the job green. Fails closed on anything that is not one of the three
+      # known verdicts.
+      - name: Fail when the probe emitted no verdict
+        if: >-
+          steps.probe.outputs.verdict != 'ok' &&
+          steps.probe.outputs.verdict != 'drift' &&
+          steps.probe.outputs.verdict != 'incomplete'
+        run: |
+          echo "::error title=Health probe emitted no verdict::verdict='${{ steps.probe.outputs.verdict }}' (step outcome: ${{ steps.probe.outcome }}). The probe died before publishing a result — treat as a broken probe, not a green run."
+          exit 1

--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -152,7 +152,10 @@ jobs:
           retention-days: 30
 
       - name: Close stale drift PRs on green
-        if: steps.probe.outcome == 'success'
+        # Gated on the probe's own verdict, not on step outcome. A tooling fault
+        # (doctor never launched) used to exit 0 and land here, auto-closing a
+        # legitimate open drift PR while half the probe was broken.
+        if: steps.probe.outputs.verdict == 'ok'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TODAY: ${{ steps.stamp.outputs.date }}
@@ -177,7 +180,9 @@ jobs:
             done
 
       - name: Open selectors-drift PR
-        if: steps.probe.outcome == 'failure' && (github.event_name != 'workflow_dispatch' || inputs.open-pr-on-fail)
+        # `drift` only — an `incomplete` verdict must NOT be filed as a
+        # claude.ai redesign; it is a broken probe and gets its own step below.
+        if: steps.probe.outputs.verdict == 'drift' && (github.event_name != 'workflow_dispatch' || inputs.open-pr-on-fail)
         uses: peter-evans/create-pull-request@v8
         with:
           # Keep this checked into the repo so a human can compare what the
@@ -216,3 +221,15 @@ jobs:
             4. If the change is a real regression in the live UI: file upstream
                + bump the patch version when the workaround lands.
             5. Close this PR once the fix lands or once `chromeUrl` recovers.
+
+      # Third path: the probe could not fully run (doctor never launched, or
+      # reported a broken toolchain). This is NOT selector drift, so no drift PR
+      # is opened above — but it must not pass either. The probe step carries
+      # `continue-on-error: true`, so without this the job would end green with
+      # only an annotation to show for it, which is precisely how a half-broken
+      # probe stayed invisible. Runs last so the artifact + streak are saved first.
+      - name: Fail on an incomplete probe
+        if: steps.probe.outputs.verdict == 'incomplete'
+        run: |
+          echo "::error title=Health probe did not fully run::verdict=incomplete — the UI anchors may be green but the tooling half of the probe is broken. This is not selector drift; see the doctor block in artifact health-${{ github.run_id }}."
+          exit 1

--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -155,7 +155,11 @@ jobs:
         # Gated on the probe's own verdict, not on step outcome. A tooling fault
         # (doctor never launched) used to exit 0 and land here, auto-closing a
         # legitimate open drift PR while half the probe was broken.
-        if: steps.probe.outputs.verdict == 'ok'
+        #
+        # Also requires zero degraded anchors: an all-degraded run still yields
+        # verdict `ok` (the tool works), and closing the drift PR that documents
+        # the rot is precisely the wrong response to unrepaired drift.
+        if: steps.probe.outputs.verdict == 'ok' && steps.probe.outputs.degraded == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TODAY: ${{ steps.stamp.outputs.date }}

--- a/cli.ts
+++ b/cli.ts
@@ -240,17 +240,29 @@ async function main(): Promise<void> {
           ok: !fail,
           generatedAt: new Date().toISOString(),
           url,
-          counts: { ok: counts['ok'] || 0, fail: counts['fail'] || 0, skip: counts['skip'] || 0 },
+          // `degraded` is counted explicitly: omitting it made the totals fail to
+          // add up to results.length, and silently hid the canonical-selector rot
+          // this status exists to surface.
+          counts: {
+            ok: counts['ok'] || 0,
+            degraded: counts['degraded'] || 0,
+            fail: counts['fail'] || 0,
+            skip: counts['skip'] || 0
+          },
           results
         };
         console.log(JSON.stringify(payload, null, 2));
       } else {
-        const icon = (s: string) => (s === 'ok' ? '✓' : s === 'fail' ? '✗' : '·');
+        // `degraded` gets its own glyph — sharing `·` with skip made "running on
+        // a superseded selector" look like "not probed".
+        const icon = (s: string) => (s === 'ok' ? '✓' : s === 'fail' ? '✗' : s === 'degraded' ? '~' : '·');
         for (const r of results) {
           const line = `${icon(r.status)} [${r.category}] ${r.id} — ${r.description}${r.detail ? ' (' + r.detail + ')' : ''}`;
           console.log(line);
         }
-        console.log(`\n${counts['ok'] || 0} ok, ${counts['fail'] || 0} fail, ${counts['skip'] || 0} skip`);
+        console.log(
+          `\n${counts['ok'] || 0} ok, ${counts['degraded'] || 0} degraded, ${counts['fail'] || 0} fail, ${counts['skip'] || 0} skip`
+        );
       }
       if (fail) process.exit(2);
       break;

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -4,7 +4,7 @@ import crypto from 'node:crypto';
 import { createBrowser, type Browser } from './browser.ts';
 import { sessionDir, saveIteration, type IterationRecord } from './artifact-store.ts';
 import { upsertSession, appendHistory, getSession, type StoredSession } from './session-store.ts';
-import { getSelectors, type Selectors } from './selectors.ts';
+import { getSelectors, orderedBranches, presenceSelector, type Selectors } from './selectors.ts';
 import { ensureCdpUp } from './cdp-ensure.ts';
 import { RunStateObserver } from './run-state.ts';
 import { OopifHtmlReader } from './oopif-reader.ts';
@@ -346,8 +346,8 @@ export class DesignerController {
     for (const cand of candidates) {
       await this.browser.activateTab(cand.index).catch(() => null);
       const composerOk = await this.browser.isVisible(this.selectors.composer.promptTextarea).catch(() => false);
-      const homeOk = this.selectors.login.signedInIndicator
-        ? await this.browser.isVisible(this.selectors.login.signedInIndicator).catch(() => false)
+      const homeOk = this._signedInMarker()
+        ? await this.browser.isVisible(this._signedInMarker()).catch(() => false)
         : false;
       if (composerOk || homeOk) return { matched: true, candidates: candidates.length };
     }
@@ -546,8 +546,8 @@ export class DesignerController {
     const interstitials = await this.clearInterstitials();
     if (interstitials.blocked) throw this._interstitialError(interstitials.blocked, picked.candidates);
 
-    const homeOk = this.selectors.login.signedInIndicator
-      ? await this.browser.isVisible(this.selectors.login.signedInIndicator).catch(() => false)
+    const homeOk = this._signedInMarker()
+      ? await this.browser.isVisible(this._signedInMarker()).catch(() => false)
       : false;
     const sessionOk = await this.browser.isVisible(this.selectors.composer.promptTextarea).catch(() => false);
     if (!homeOk && !sessionOk) {
@@ -627,7 +627,7 @@ export class DesignerController {
       // the click.
       await this._submitPrompt(seed, {
         textarea: this.selectors.home.creator,
-        sendButton: this.selectors.home.createButton
+        sendButton: orderedBranches(this.selectors.home.createButton, this.selectors.homeLegacy?.createButton)
       });
 
       let inSession = false;
@@ -664,9 +664,22 @@ export class DesignerController {
   // composer — the home create surface is a plain <textarea> + button[title="Create"]
   // (see createSession). The fill branch already handles both <textarea> (native
   // value setter) and contenteditable (synthetic paste), so only the selectors differ.
-  async _submitPrompt(prompt: string, sel?: { textarea?: string; sendButton?: string }): Promise<void> {
+  // Presence-only marker for "is this tab a signed-in claude.ai/design surface".
+  // Canonical + legacy joined is safe HERE because the caller only asks whether
+  // one is present, never which element to act on.
+  _signedInMarker(): string {
+    return presenceSelector(this.selectors.login.signedInIndicator, this.selectors.loginLegacy?.signedInIndicator);
+  }
+
+  async _submitPrompt(prompt: string, sel?: { textarea?: string; sendButton?: string | string[] }): Promise<void> {
     const promptTextarea = sel?.textarea ?? this.selectors.composer.promptTextarea;
     const sendButton = sel?.sendButton ?? this.selectors.composer.sendButton;
+    // Ordered branches, resolved in-page one at a time. A comma-joined list
+    // would hand back whichever matched first in DOCUMENT ORDER — so a stale or
+    // hidden duplicate earlier in the page could win over the canonical control
+    // and we would click the wrong button.
+    const sendButtons = Array.isArray(sendButton) ? sendButton.filter(Boolean) : [sendButton];
+    const sendButtonsJson = JSON.stringify(sendButtons);
     await this.browser.waitFor(promptTextarea);
     // The composer has shipped as both a React-controlled <textarea> and a
     // ProseMirror contenteditable <div> — branch on what's actually there.
@@ -718,7 +731,8 @@ export class DesignerController {
         `(() => {
           const el = document.querySelector(${JSON.stringify(promptTextarea)});
           const hasText = !!el && (el instanceof HTMLTextAreaElement ? el.value : (el.textContent || '')).trim().length > 0;
-          const b = document.querySelector(${JSON.stringify(sendButton)});
+          let b = null;
+          for (const s of ${sendButtonsJson}) { b = document.querySelector(s); if (b) break; }
           const enabled = !!b && !b.disabled && b.getAttribute('aria-disabled') !== 'true';
           return hasText && enabled;
         })()`
@@ -727,8 +741,9 @@ export class DesignerController {
     }
     await this.browser.evalValue<boolean>(
       `(() => {
-        const b = document.querySelector(${JSON.stringify(sendButton)});
-        if (!b) throw new Error('send button not found');
+        let b = null;
+        for (const s of ${sendButtonsJson}) { b = document.querySelector(s); if (b) break; }
+        if (!b) throw new Error('send button not found (tried: ' + ${sendButtonsJson}.join(' | ') + ')');
         b.click();
         return true;
       })()`
@@ -992,28 +1007,63 @@ export class DesignerController {
         // 2026-07 redesign: projects moved from a flat list of text-bearing links
         // to a <section data-testid="projects-list"> of <tr data-testid=
         // "project-row">. The row's <a href="/design/p/<uuid>"> is now an EMPTY
-        // overlay link — reading its text (what the 2026-06 scrape did) yields
-        // null for every project. The name now lives in the row's first cell, and
-        // is mirrored onto the anchor's aria-label. Resolve through all three, in
-        // most- to least-structured order, so this survives either layout:
-        // anchor text (old flat list) -> aria-label -> the row's first cell.
-        // Anchor-keyed, not row-keyed, because the href is the only place the
-        // uuid appears; dedupe by uuid (a row can wrap more than one anchor).
-        const links = Array.from(document.querySelectorAll('a[href*="/design/p/"]'));
-        const seen = new Set();
-        const out = [];
-        for (const a of links) {
-          const href = a.href || a.getAttribute('href') || '';
-          const m = href.match(/\\/design\\/p\\/([a-f0-9-]+)/i);
-          if (!m || seen.has(m[1])) continue;
-          seen.add(m[1]);
-          const row = a.closest('[data-testid="project-row"], tr');
+        // overlay link — reading its text (what the 2026-06 scrape did) yielded
+        // null for every project. The name lives in the row's first cell and is
+        // mirrored onto the anchor's aria-label.
+        const LINK_SEL = ${JSON.stringify(this.selectors.home.projectLink)};
+        const ROW_SEL = ${JSON.stringify(this.selectors.home.projectCard)};
+
+        // Parse the uuid from the PATHNAME, not a substring of the whole href:
+        // a settings/breadcrumb link, or any URL carrying a project link in a
+        // query param, would otherwise match and contribute its own text as a
+        // project name.
+        const idOf = (a) => {
+          const raw = a.getAttribute('href') || '';
+          let pathname = raw;
+          try { pathname = new URL(a.href || raw, document.baseURI).pathname; } catch (e) { /* keep raw */ }
+          const m = pathname.match(/^\\/design\\/p\\/([0-9a-f-]{8,})$/i);
+          return m ? m[1] : null;
+        };
+
+        const nameFrom = (a) => {
+          // closest() with a comma list returns the NEAREST ancestor matching
+          // EITHER branch — so a nested <tr> would beat the real project row.
+          // Try the specific row first, only then the generic tag.
+          const row = a.closest(ROW_SEL) || a.closest('tr');
           const firstCell = row ? row.querySelector('td') : null;
-          const name =
-            (a.textContent || '').trim() ||
+          return (
+            (a.textContent || '').trim() ||           // old flat-list layout
             (a.getAttribute('aria-label') || '').trim() ||
-            (firstCell ? (firstCell.textContent || '').trim() : '');
-          out.push({ name: name || null, sub: null, url: href });
+            (firstCell ? (firstCell.textContent || '').trim() : '')
+          );
+        };
+
+        // Collect ALL candidates per uuid before choosing. The previous version
+        // marked a uuid seen at first sight, so when a row carried more than one
+        // anchor (an icon/thumbnail link before the named overlay link) the
+        // nameless one won and the good one was skipped forever — emitting
+        // name:null for a project whose name was right there.
+        const byId = new Map();
+        for (const a of Array.from(document.querySelectorAll(LINK_SEL))) {
+          const id = idOf(a);
+          if (!id) continue;
+          const href = a.href || a.getAttribute('href') || '';
+          const entry = byId.get(id) || { url: href, names: [] };
+          if (!entry.url) entry.url = href;
+          const n = nameFrom(a);
+          if (n) entry.names.push(n);
+          byId.set(id, entry);
+        }
+
+        const out = [];
+        for (const [, entry] of byId) {
+          // Prefer the shortest non-empty candidate: decorated variants tend to
+          // ADD to the bare name ("Open Acme Redesign", "Acme Redesign, edited
+          // yesterday"), so the shortest is the closest to the name itself.
+          const name = entry.names.length
+            ? entry.names.slice().sort((x, y) => x.length - y.length)[0]
+            : null;
+          out.push({ name: name || null, sub: null, url: entry.url });
         }
         return out;
       })()`

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -673,7 +673,8 @@ export class DesignerController {
 
   async _submitPrompt(prompt: string, sel?: { textarea?: string; sendButton?: string | string[] }): Promise<void> {
     const promptTextarea = sel?.textarea ?? this.selectors.composer.promptTextarea;
-    const sendButton = sel?.sendButton ?? this.selectors.composer.sendButton;
+    const sendButton =
+      sel?.sendButton ?? orderedBranches(this.selectors.composer.sendButton, this.selectors.composerLegacy?.sendButton);
     // Ordered branches, resolved in-page one at a time. A comma-joined list
     // would hand back whichever matched first in DOCUMENT ORDER — so a stale or
     // hidden duplicate earlier in the page could win over the canonical control
@@ -1001,7 +1002,12 @@ export class DesignerController {
   async listProjects(): Promise<Array<{ name: string | null; sub: string | null; url: string | null }>> {
     await this.openGuarded(DESIGN_HOME);
     await this.browser.waitLoad('networkidle').catch(() => null);
-    await this.browser.waitFor(this.selectors.home.projectsList).catch(() => null);
+    // Presence-only wait, so canonical+legacy may be probed together — otherwise
+    // a degraded home (canonical list testid gone) burns the full timeout before
+    // proceeding, even though the scrape below would have worked.
+    await this.browser
+      .waitFor(presenceSelector(this.selectors.home.projectsList, this.selectors.homeLegacy?.projectsList))
+      .catch(() => null);
     const json = await this.browser.evalValue<Array<{ name: string | null; sub: string | null; url: string | null }>>(
       `(() => {
         // 2026-07 redesign: projects moved from a flat list of text-bearing links

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -1025,17 +1025,30 @@ export class DesignerController {
           return m ? m[1] : null;
         };
 
-        const nameFrom = (a) => {
+        // Name candidates, tagged with WHERE they came from. Source is what
+        // decides, not string length: a control link ("Open", "Settings") is
+        // shorter than the real name, so a shortest-wins rule picks the button
+        // label on exactly the multi-link row this function exists to handle.
+        //
+        // Priority, most to least authoritative:
+        //   rowCell    — the row's name column; shared by every link in the row,
+        //                so multi-link rows converge on one answer
+        //   ariaLabel  — mirrors the name on the overlay link
+        //   anchorText — the legacy flat-list layout, where the name WAS the
+        //                link text; also the most likely to be a control label,
+        //                hence last.
+        const NAME_SOURCES = ['rowCell', 'ariaLabel', 'anchorText'];
+        const candidatesFrom = (a) => {
           // closest() with a comma list returns the NEAREST ancestor matching
           // EITHER branch — so a nested <tr> would beat the real project row.
           // Try the specific row first, only then the generic tag.
           const row = a.closest(ROW_SEL) || a.closest('tr');
           const firstCell = row ? row.querySelector('td') : null;
-          return (
-            (a.textContent || '').trim() ||           // old flat-list layout
-            (a.getAttribute('aria-label') || '').trim() ||
-            (firstCell ? (firstCell.textContent || '').trim() : '')
-          );
+          return {
+            rowCell: firstCell ? (firstCell.textContent || '').trim() : '',
+            ariaLabel: (a.getAttribute('aria-label') || '').trim(),
+            anchorText: (a.textContent || '').trim()
+          };
         };
 
         // Collect ALL candidates per uuid before choosing. The previous version
@@ -1048,21 +1061,21 @@ export class DesignerController {
           const id = idOf(a);
           if (!id) continue;
           const href = a.href || a.getAttribute('href') || '';
-          const entry = byId.get(id) || { url: href, names: [] };
+          const entry = byId.get(id) || { url: href, sources: {} };
           if (!entry.url) entry.url = href;
-          const n = nameFrom(a);
-          if (n) entry.names.push(n);
+          const c = candidatesFrom(a);
+          // First non-empty value per source wins; later links only fill gaps,
+          // so one link's missing aria-label cannot erase another's.
+          for (const k of NAME_SOURCES) if (!entry.sources[k] && c[k]) entry.sources[k] = c[k];
           byId.set(id, entry);
         }
 
         const out = [];
         for (const [, entry] of byId) {
-          // Prefer the shortest non-empty candidate: decorated variants tend to
-          // ADD to the bare name ("Open Acme Redesign", "Acme Redesign, edited
-          // yesterday"), so the shortest is the closest to the name itself.
-          const name = entry.names.length
-            ? entry.names.slice().sort((x, y) => x.length - y.length)[0]
-            : null;
+          let name = null;
+          for (const k of NAME_SOURCES) {
+            if (entry.sources[k]) { name = entry.sources[k]; break; }
+          }
           out.push({ name: name || null, sub: null, url: entry.url });
         }
         return out;

--- a/designer-controller.ts
+++ b/designer-controller.ts
@@ -1027,7 +1027,12 @@ export class DesignerController {
           const raw = a.getAttribute('href') || '';
           let pathname = raw;
           try { pathname = new URL(a.href || raw, document.baseURI).pathname; } catch (e) { /* keep raw */ }
-          const m = pathname.match(/^\\/design\\/p\\/([0-9a-f-]{8,})$/i);
+          // Optional trailing slash, but NOT arbitrary subroutes. The review
+          // proposed (?:\\/|$), which would also admit /design/p/<uuid>/settings —
+          // re-opening the decoy vector an earlier round closed, where a nav or
+          // breadcrumb link outside any row becomes a phantom project named
+          // after its own link text.
+          const m = pathname.match(/^\\/design\\/p\\/([0-9a-f-]{8,})\\/?$/i);
           return m ? m[1] : null;
         };
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cli": "tsx cli.ts",
     "setup": "tsx cli.ts setup",
     "doctor": "tsx cli.ts doctor",
-    "test": "npm run build && node --test tests/cli-metadata.test.mjs && node --import tsx --test tests/run-state.*.test.mjs tests/cdp-trace.*.test.mjs tests/ui-drift.*.test.mjs tests/interstitials.*.test.mjs tests/cdp-dialog.*.test.mjs",
+    "test": "npm run build && node --test tests/cli-metadata.test.mjs && node --import tsx --test tests/run-state.*.test.mjs tests/cdp-trace.*.test.mjs tests/ui-drift.*.test.mjs tests/interstitials.*.test.mjs tests/health-apparatus.*.test.mjs tests/cdp-dialog.*.test.mjs",
     "check": "tsc --noEmit",
     "build": "tsc -p tsconfig.build.json",
     "prepack": "npm run check && npm run build",

--- a/scripts/auto-heal.ts
+++ b/scripts/auto-heal.ts
@@ -30,7 +30,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync, execSync } from 'node:child_process';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import Anthropic from '@anthropic-ai/sdk';
 import { REPO_ROOT } from '../repo-root.ts';
 import { createBrowser } from '../browser.ts';
@@ -1048,7 +1048,12 @@ async function main(): Promise<void> {
 // Only run when executed as a script. Importing this module (unit tests reaching
 // for classifyCandidates) must not trigger a heal run — it shells out to git/gh
 // and calls the Anthropic API.
-const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+// realpath BOTH sides: import.meta.url is already resolved through symlinks, so
+// comparing it to a raw argv[1] makes the guard silently false under a symlinked
+// checkout (or an npm-linked bin) — the script would then be imported-but-never-run.
+// Latent today (both workflows invoke by relative path), cheap to make robust.
+const entry = process.argv[1] ? fs.realpathSync(process.argv[1]) : '';
+const invokedDirectly = entry !== '' && fs.realpathSync(fileURLToPath(import.meta.url)) === entry;
 if (invokedDirectly)
   main().catch((e: Error) => {
   // An uncaught exception is a programmer error (bad artifact shape, missing

--- a/scripts/auto-heal.ts
+++ b/scripts/auto-heal.ts
@@ -19,6 +19,12 @@
 //
 // All failure modes exit 0 — auto-heal is best-effort. The drift PR opened
 // by daily-health stays as the human-readable diagnostic regardless.
+//
+// ONE carve-out: `reason=blind-unpatchable` (nothing auto-patchable while
+// anchors are failing) still exits 0 here, but the workflow gates on that reason
+// and fails the job. That state is not a best-effort miss — it is a standing
+// defect in auto-heal that no future run resolves, and an ::error annotation
+// alone does not change a step's outcome.
 
 import fs from 'node:fs';
 import os from 'node:os';
@@ -29,6 +35,9 @@ import Anthropic from '@anthropic-ai/sdk';
 import { REPO_ROOT } from '../repo-root.ts';
 import { createBrowser } from '../browser.ts';
 import { canPatch, findAnchor, patchSelector } from './anchor-patcher.ts';
+import { getSelectors } from '../selectors.ts';
+
+const SEL = getSelectors();
 
 /**
  * Split triage candidates by WHY each one can or cannot be healed.
@@ -104,8 +113,14 @@ const ANTHROPIC_MODEL = 'claude-opus-4-7';
 // Navigation targets for the fresh snapshot auto-heal captures on the runner
 // (daily-health no longer uploads page.html/page.png — see captureCurrentSnapshot).
 const HOME_URL = 'https://claude.ai/design';
-const HOME_READY_SEL = '[data-testid="project-creator"]';
-const SESSION_READY_SEL = '[data-testid="chat-composer-input"]';
+// Second stale copy of the readiness gates (ci-health.ts had the other). The
+// home one was `[data-testid="project-creator"]`, dead since a redesign, so the
+// snapshot auto-heal feeds to the LLM was captured after a full timeout with no
+// readiness guarantee — i.e. possibly of a half-painted page, which is a bad
+// basis for inferring a replacement selector. Sourced from selectors.json so a
+// drift repair fixes every consumer at once.
+const HOME_READY_SEL = SEL.home.creator;
+const SESSION_READY_SEL = SEL.composer.promptTextarea;
 const HTML_CAP_BYTES = 60_000;
 
 // Priority: session anchors regressing breaks the canary loop hardest, so
@@ -124,7 +139,10 @@ interface ProbeResult {
   category: 'home' | 'session' | 'share' | 'pattern';
   description: string;
   requires: 'home' | 'session' | 'any';
-  status: 'ok' | 'fail' | 'skip';
+  // Mirrors ProbeStatus in ui-anchors.ts. `degraded` (working only via a
+  // superseded selector branch) is deliberately NOT treated as a fail below —
+  // but the type must admit it, or reading a current artifact is a lie.
+  status: 'ok' | 'degraded' | 'fail' | 'skip';
   detail?: string;
   phase?: 'home' | 'session';
 }
@@ -134,7 +152,7 @@ interface ArtifactJson {
   reason?: string;
   health?: {
     ok: boolean;
-    counts: { ok: number; fail: number; skip: number };
+    counts: { ok: number; degraded?: number; fail: number; skip: number };
     results: ProbeResult[];
   };
   diagnostics?: { url: string; htmlBytes: number; screenshotPath?: string } | null;

--- a/scripts/auto-heal.ts
+++ b/scripts/auto-heal.ts
@@ -24,10 +24,73 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync, execSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 import Anthropic from '@anthropic-ai/sdk';
 import { REPO_ROOT } from '../repo-root.ts';
 import { createBrowser } from '../browser.ts';
 import { canPatch, findAnchor, patchSelector } from './anchor-patcher.ts';
+
+/**
+ * Split triage candidates by WHY each one can or cannot be healed.
+ *
+ * This exists because the old triage collapsed two opposite situations into one
+ * log line ("all candidates either complex or in cooldown"):
+ *
+ *   - cooldown        -> temporary; it resolves on its own in COOLDOWN_DAYS
+ *   - not patchable   -> PERMANENT; it will never resolve without a code change
+ *
+ * Conflating them is how auto-heal ran green for the nine days of #118-#126.
+ * Centralizing selectors into selectors.json (a correct decision) rewrote every
+ * anchor from `hasSelector(b, '<literal>')` to `hasSelector(b, SEL.home.creator)`,
+ * and the AST patcher only rewrites string literals — so EVERY anchor became
+ * unpatchable at once. `home.creator` sat at streak 9 while auto-heal reported
+ * conclusion "success" daily. Structural blindness must be loud and must not
+ * look like "nothing to do".
+ *
+ * Pure + exported so the decision is unit-testable without a browser, an API
+ * key, or a live artifact.
+ */
+export interface CandidateClassification {
+  /** Healable right now. */
+  eligible: string[];
+  /** Permanently blind: the patcher cannot express a fix for this anchor. */
+  unpatchable: string[];
+  /** Temporarily skipped; will become eligible again. */
+  cooling: string[];
+  /** Failed anchor-id shape validation (shell-injection gate). */
+  invalid: string[];
+}
+
+export function classifyCandidates(
+  candidates: string[],
+  probes: {
+    canPatch: (id: string) => boolean;
+    inCooldown: (id: string) => boolean;
+    isValidId: (id: string) => boolean;
+  }
+): CandidateClassification {
+  const out: CandidateClassification = { eligible: [], unpatchable: [], cooling: [], invalid: [] };
+  for (const id of candidates) {
+    if (!probes.isValidId(id)) out.invalid.push(id);
+    else if (!probes.canPatch(id)) out.unpatchable.push(id);
+    else if (probes.inCooldown(id)) out.cooling.push(id);
+    else out.eligible.push(id);
+  }
+  return out;
+}
+
+/**
+ * True when auto-heal has real work queued but cannot act on ANY of it for
+ * structural reasons. This is the state that must never be silent again.
+ */
+export function isStructurallyBlind(c: CandidateClassification): boolean {
+  return c.eligible.length === 0 && c.unpatchable.length > 0;
+}
+
+/** Anchor ids the patcher can currently rewrite — reality, not intent. */
+export function patchableAnchorIds(anchorsSource: string, ids: string[]): string[] {
+  return ids.filter((id) => canPatch(anchorsSource, id));
+}
 
 const HEALTH_DIR = path.join(REPO_ROOT, 'artifacts', 'health');
 const STREAK_PATH = path.join(HEALTH_DIR, 'streak.json');
@@ -367,30 +430,69 @@ function triage(): void {
 
   const anchorsSource = fs.readFileSync(ANCHORS_PATH, 'utf8');
 
-  for (const id of sorted) {
-    if (!canPatch(anchorsSource, id)) {
-      console.log(`[auto-heal triage] ${id} — check shape not auto-patchable, skipping`);
-      continue;
-    }
-    if (isWithinCooldown(id)) {
-      console.log(`[auto-heal triage] ${id} — within ${COOLDOWN_DAYS}-day cooldown, skipping`);
-      continue;
-    }
-    if (!isValidAnchorId(id)) {
-      // Should never happen for source-defined UI_ANCHORS, but the shape
-      // gate exists because anchor-id flows into a shell-interpolated
-      // workflow command. A future code path that adds streak keys from
-      // a non-anchor source must not be able to inject here.
-      console.log(`[auto-heal triage] ${id} — failed anchor-id shape validation, skipping`);
-      continue;
-    }
-    console.log(`[auto-heal triage] selected ${id} (streak=${streak[id]}, category=${byId.get(id)?.category ?? 'unknown'})`);
+  const classified = classifyCandidates(sorted, {
+    canPatch: (id) => canPatch(anchorsSource, id),
+    inCooldown: isWithinCooldown,
+    // Shape gate: anchor-id flows into a shell-interpolated workflow command,
+    // so a future code path adding streak keys from a non-anchor source must
+    // not be able to inject here.
+    isValidId: isValidAnchorId
+  });
+
+  for (const id of classified.unpatchable) {
+    console.log(`[auto-heal triage] ${id} — check shape not auto-patchable`);
+  }
+  for (const id of classified.cooling) {
+    console.log(`[auto-heal triage] ${id} — within ${COOLDOWN_DAYS}-day cooldown, skipping`);
+  }
+  for (const id of classified.invalid) {
+    console.log(`[auto-heal triage] ${id} — failed anchor-id shape validation, skipping`);
+  }
+
+  const selected = classified.eligible[0];
+  if (selected) {
+    console.log(`[auto-heal triage] selected ${selected} (streak=${streak[selected]}, category=${byId.get(selected)?.category ?? 'unknown'})`);
     ghOutput('action', 'heal');
-    ghOutput('anchor-id', id);
+    ghOutput('anchor-id', selected);
     return;
   }
 
-  console.log('[auto-heal triage] all candidates either complex or in cooldown — skipping');
+  // Nothing healable. Distinguish "wait for the cooldown" from "auto-heal
+  // physically cannot fix this, ever" — the second one is a standing defect in
+  // this tool and needs a human, not another quiet day.
+  if (isStructurallyBlind(classified)) {
+    const ids = classified.unpatchable.join(', ');
+    console.log(
+      `::error title=auto-heal is structurally blind::${classified.unpatchable.length} anchor(s) have failed for ${STREAK_THRESHOLD}+ runs and NONE are auto-patchable: ${ids}. auto-heal cannot fix these — a human must.`
+    );
+    const driftPr = findDriftPrNumber(date);
+    if (driftPr != null && !prHasLabel(driftPr, 'auto-heal-blind')) {
+      gh([
+        'pr',
+        'comment',
+        String(driftPr),
+        '--body',
+        [
+          '## Auto-heal cannot fix this',
+          '',
+          `These anchors have failed for ${STREAK_THRESHOLD}+ consecutive runs, but **none of them are auto-patchable**, so auto-heal has taken no action and will not take any on future runs either:`,
+          '',
+          ...classified.unpatchable.map((id) => `- \`${id}\` (streak=${streak[id]})`),
+          '',
+          'The AST patcher can only rewrite anchors shaped `hasSelector(b, \'<string literal>\')`. Anchors that read their selector from `selectors.json` (`SEL.group.key`) are outside its reach, as are `hasButtonMatching` / custom-walker checks.',
+          '',
+          '**This will not resolve on its own.** Repair the selector by hand, or extend the patcher.'
+        ].join('\n')
+      ]);
+      gh(['pr', 'edit', String(driftPr), '--add-label', 'auto-heal-blind']);
+    }
+    ghOutput('action', 'skip');
+    ghOutput('reason', 'blind-unpatchable');
+    ghOutput('blind-anchors', classified.unpatchable.join(','));
+    return;
+  }
+
+  console.log('[auto-heal triage] all candidates in cooldown — skipping');
   ghOutput('action', 'skip');
   ghOutput('reason', 'no-eligible-candidate');
 }
@@ -903,7 +1005,12 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((e: Error) => {
+// Only run when executed as a script. Importing this module (unit tests reaching
+// for classifyCandidates) must not trigger a heal run — it shells out to git/gh
+// and calls the Anthropic API.
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly)
+  main().catch((e: Error) => {
   // An uncaught exception is a programmer error (bad artifact shape, missing
   // tool, SDK contract drift). Exit 1 so the workflow goes red — masking it
   // as exit 0 would put it in the same silent-no-op class the expected-skip

--- a/scripts/auto-heal.ts
+++ b/scripts/auto-heal.ts
@@ -358,6 +358,7 @@ function triage(): void {
     console.log('[auto-heal triage] no artifact found — download step should have provided one');
     ghOutput('action', 'skip');
     ghOutput('reason', 'no-artifact');
+    ghOutput('blind', 'false');
     process.exit(1);
   }
   const { data, date } = artifact;
@@ -367,6 +368,7 @@ function triage(): void {
     console.log('[auto-heal triage] artifact reason=cdp-unreachable — infra failure, skipping');
     ghOutput('action', 'skip');
     ghOutput('reason', 'cdp-unreachable');
+    ghOutput('blind', 'false');
     return;
   }
 
@@ -374,6 +376,7 @@ function triage(): void {
     console.log('[auto-heal triage] artifact has no health.results — malformed');
     ghOutput('action', 'skip');
     ghOutput('reason', 'no-results');
+    ghOutput('blind', 'false');
     process.exit(1);
   }
 
@@ -394,8 +397,36 @@ function triage(): void {
     console.log(`[auto-heal triage] no anchors at streak >= ${STREAK_THRESHOLD}`);
     ghOutput('action', 'skip');
     ghOutput('reason', 'below-threshold');
+    ghOutput('blind', 'false');
     return;
   }
+
+  // Classify BEFORE any early return. The wholesale-redesign branch below used
+  // to bail first, so a wholesale regression in which nothing was patchable
+  // emitted reason=wholesale-redesign and never reported blindness — leaving the
+  // workflow green in the worst case (many anchors down, auto-heal powerless).
+  const byId = new Map<string, ProbeResult>();
+  for (const r of data.health.results) {
+    if (!byId.has(r.id)) byId.set(r.id, r);
+  }
+
+  // Sort candidates by priority bucket
+  const sorted = [...candidates].sort((a, b) => {
+    const ca = byId.get(a)?.category ?? 'pattern';
+    const cb = byId.get(b)?.category ?? 'pattern';
+    return PRIORITY.indexOf(ca) - PRIORITY.indexOf(cb);
+  });
+
+  const anchorsSource = fs.readFileSync(ANCHORS_PATH, 'utf8');
+
+  const classified = classifyCandidates(sorted, {
+    canPatch: (id) => canPatch(anchorsSource, id),
+    inCooldown: isWithinCooldown,
+    // Shape gate: anchor-id flows into a shell-interpolated workflow command,
+    // so a future code path adding streak keys from a non-anchor source must
+    // not be able to inject here.
+    isValidId: isValidAnchorId
+  });
 
   if (candidates.length >= WHOLESALE_THRESHOLD) {
     console.log(`[auto-heal triage] ${candidates.length} anchors regressed — wholesale-redesign suspected`);
@@ -429,34 +460,18 @@ function triage(): void {
     }
     ghOutput('action', 'skip');
     ghOutput('reason', 'wholesale-redesign');
+    // A wholesale regression can ALSO be structurally blind; the two are
+    // independent facts, so blindness gets its own output rather than competing
+    // for the single `reason` slot.
+    ghOutput('blind', String(isStructurallyBlind(classified)));
+    if (isStructurallyBlind(classified)) {
+      console.log(`::error title=auto-heal is structurally blind::a wholesale regression is suspected AND none of the ${classified.unpatchable.length} failing anchors are auto-patchable: ${classified.unpatchable.join(', ')}`);
+    }
     ghOutput('candidate-count', String(candidates.length));
     return;
   }
 
   // Map id → category for priority sort
-  const byId = new Map<string, ProbeResult>();
-  for (const r of data.health.results) {
-    if (!byId.has(r.id)) byId.set(r.id, r);
-  }
-
-  // Sort candidates by priority bucket
-  const sorted = [...candidates].sort((a, b) => {
-    const ca = byId.get(a)?.category ?? 'pattern';
-    const cb = byId.get(b)?.category ?? 'pattern';
-    return PRIORITY.indexOf(ca) - PRIORITY.indexOf(cb);
-  });
-
-  const anchorsSource = fs.readFileSync(ANCHORS_PATH, 'utf8');
-
-  const classified = classifyCandidates(sorted, {
-    canPatch: (id) => canPatch(anchorsSource, id),
-    inCooldown: isWithinCooldown,
-    // Shape gate: anchor-id flows into a shell-interpolated workflow command,
-    // so a future code path adding streak keys from a non-anchor source must
-    // not be able to inject here.
-    isValidId: isValidAnchorId
-  });
-
   for (const id of classified.unpatchable) {
     console.log(`[auto-heal triage] ${id} — check shape not auto-patchable`);
   }
@@ -472,6 +487,7 @@ function triage(): void {
     console.log(`[auto-heal triage] selected ${selected} (streak=${streak[selected]}, category=${byId.get(selected)?.category ?? 'unknown'})`);
     ghOutput('action', 'heal');
     ghOutput('anchor-id', selected);
+    ghOutput('blind', 'false');
     return;
   }
 
@@ -506,6 +522,7 @@ function triage(): void {
     }
     ghOutput('action', 'skip');
     ghOutput('reason', 'blind-unpatchable');
+    ghOutput('blind', 'true');
     ghOutput('blind-anchors', classified.unpatchable.join(','));
     return;
   }
@@ -513,6 +530,7 @@ function triage(): void {
   console.log('[auto-heal triage] all candidates in cooldown — skipping');
   ghOutput('action', 'skip');
   ghOutput('reason', 'no-eligible-candidate');
+  ghOutput('blind', 'false');
 }
 
 // ---- heal ----

--- a/scripts/auto-heal.ts
+++ b/scripts/auto-heal.ts
@@ -35,6 +35,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { REPO_ROOT } from '../repo-root.ts';
 import { createBrowser } from '../browser.ts';
 import { canPatch, findAnchor, patchSelector } from './anchor-patcher.ts';
+import { isFailing } from '../ui-anchors.ts';
 import { getSelectors } from '../selectors.ts';
 
 const SEL = getSelectors();
@@ -912,7 +913,10 @@ async function heal(anchorId: string): Promise<void> {
     ghOutput('reason', 're-probe-anchor-missing');
     return;
   }
-  const nonOk = entriesForAnchor.filter((r) => r.status !== 'ok');
+  // `degraded` means the anchor WORKS (via a superseded branch) — the patch did
+  // its job. Treating anything !== 'ok' as failure reverted a working patch and
+  // then reported the heal as unsuccessful.
+  const nonOk = entriesForAnchor.filter((r) => isFailing(r.status));
   if (nonOk.length > 0) {
     console.log(
       `[auto-heal heal] re-probe shows ${anchorId} still failing in ${nonOk.length}/${entriesForAnchor.length} phase(s) — reverting`

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -157,14 +157,22 @@ export function probeVerdict(input: { anchorFail: boolean; doctorSpawnError: str
   // ONLY a failure to launch means the probe did not run. A non-zero doctor exit
   // deliberately does NOT gate.
   //
-  // `designer doctor` exits 2 if ANY of its checks fails, several of which are
-  // orthogonal to whether this probe is valid — and one fires routinely: doctor
-  // runs BEFORE the probe navigates, and ensureCdp() may have just relaunched
-  // Chrome, so the "claude.ai/design tab" check (status 'fail') sees a browser
-  // with no design tab yet. Gating on the exit code would therefore fail the
-  // daily job on ordinary runs and permanently block `Close stale drift PRs on
-  // green`, turning a diagnostic into an outage. A non-zero exit is surfaced via
-  // the artifact + an ::error annotation instead; it is information, not a gate.
+  // Reproduced 2026-07-26 rather than argued: doctor was run against a CDP Chrome
+  // with NO design tab open and exited 0 — that check is status 'warn' (⚠), not
+  // 'fail'. An earlier revision of this comment claimed it fired routinely after
+  // an ensureCdp relaunch; that was wrong, and this corrects it.
+  //
+  // Doctor's six real 'fail' branches: node_modules missing, agent-browser
+  // missing, selectors.json missing, CDP HTTP error, signed-out, MCP
+  // registration. Only the LAST is orthogonal to whether this probe is valid,
+  // and the rest are already covered without the exit code — signed-out fails the
+  // login.signedIn anchor (-> drift), and a missing selectors.json or
+  // agent-browser makes the probe itself throw (-> incomplete).
+  //
+  // So gating on the exit code buys almost nothing while risking a block on
+  // `Close stale drift PRs on green` for an unrelated Claude Code registration
+  // fault. A non-zero exit is surfaced in the artifact + an ::error annotation:
+  // information, not a gate.
   if (input.doctorSpawnError !== null) return 'incomplete';
   return 'ok';
 }

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -10,10 +10,14 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 import { createBrowser, type Browser } from '../browser.ts';
-import { runHealth, type ProbeResult } from '../ui-anchors.ts';
+import { runHealth, UI_ANCHORS, type ProbeResult } from '../ui-anchors.ts';
 import { REPO_ROOT } from '../repo-root.ts';
+import { getSelectors } from '../selectors.ts';
 import { classifyInterstitial, INTERSTITIAL_PROBE_EXPR, type InterstitialKind, type InterstitialProbe } from '../interstitials.ts';
+
+const SEL = getSelectors();
 
 const CDP_PORT = process.env.DESIGNER_CDP || '9222';
 const CHROME_PROFILE = path.join(os.homedir(), '.chrome-designer-profile');
@@ -25,25 +29,54 @@ const CHROME_APP = '/Applications/Google Chrome.app';
 // loudly). 15s adaptive wait — claude.ai/design's SPA usually paints in 2-4s;
 // 15s is the runner-cold-load ceiling before we proceed and let anchors fail.
 const HOME_URL = 'https://claude.ai/design';
-const HOME_READY_SEL = '[data-testid="project-creator"]';
-const SESSION_READY_SEL = '[data-testid="chat-composer-input"]';
+// Readiness gates, resolved from selectors.json rather than inlined. These were
+// hardcoded literals until 2026-07, and the home one ([data-testid="project-creator"])
+// had been dead since a redesign — so every run burned the full BROWSER_TIMEOUT_MS
+// waiting for an element that could never appear, then proceeded WITHOUT a
+// readiness guarantee. adaptiveWait only logs on timeout, so the probe looked
+// healthy the whole time. Sourcing them here means a drift repair in
+// selectors.json fixes the gate too, instead of leaving a second stale copy.
+const HOME_READY_SEL = SEL.home.creator;
+const SESSION_READY_SEL = SEL.composer.promptTextarea;
 const BROWSER_TIMEOUT_MS = 15_000;
 
 interface DoctorRun {
   exitCode: number;
   stdout: string;
   stderr: string;
+  /** Non-null when the process never launched (ENOENT, EACCES, timeout kill). */
+  spawnError: string | null;
+}
+
+// Resolve the CLI entry point from package.json's `bin` map instead of guessing
+// the filename. This spawned `bin/designer` (no extension) from 2026-05 until
+// 2026-07-25; the real file is `bin/designer.mjs`, so every run failed ENOENT,
+// `r.status` came back null, `?? -1` rendered it as exitCode -1, and r.error was
+// discarded — which is why stdout AND stderr were both empty. `designer doctor`,
+// i.e. the entire tooling-state half of this probe, had never once executed.
+// Reading the path from the manifest means a rename can't silently re-break it.
+export function resolveDoctorBin(repoRoot: string = REPO_ROOT): string {
+  const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')) as {
+    bin?: string | Record<string, string>;
+  };
+  const rel = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin?.designer;
+  if (!rel) throw new Error('package.json declares no `bin` entry for designer');
+  return path.join(repoRoot, rel);
 }
 
 function runDoctor(): DoctorRun {
   // Shell out so we get the same view a human would running `designer doctor`.
   // Doctor has no --json today; we capture raw text and the exit code.
-  const bin = path.join(REPO_ROOT, 'bin', 'designer');
+  const bin = resolveDoctorBin();
   const r = spawnSync(bin, ['doctor'], { encoding: 'utf8', timeout: 60_000 });
   return {
     exitCode: r.status ?? -1,
     stdout: r.stdout || '',
-    stderr: r.stderr || ''
+    stderr: r.stderr || '',
+    // A failure to LAUNCH is not an exit code. Keep it distinguishable in the
+    // artifact so "never ran" can never again read the same as "ran and was
+    // unhappy" — that ambiguity is what hid this bug for two months.
+    spawnError: r.error ? `${(r.error as NodeJS.ErrnoException).code ?? 'ERROR'}: ${r.error.message}` : null
   };
 }
 
@@ -168,7 +201,13 @@ function updateStreak(outDir: string, results: ProbeResult[]): void {
     const prev = verdict.get(r.id);
     if (r.status === 'fail') {
       verdict.set(r.id, 'fail'); // fail wins over ok
-    } else if (r.status === 'ok' && prev !== 'fail') {
+    } else if ((r.status === 'ok' || r.status === 'degraded') && prev !== 'fail') {
+      // `degraded` resets the streak like `ok`. It is unrepaired drift, but the
+      // anchor is NOT in this run's `fail` set, so auto-heal could never select
+      // it as a candidate — counting it as a fail would grow a streak that can
+      // never be acted on and could push the count past WHOLESALE_THRESHOLD,
+      // causing a false wholesale-redesign bail. Degradation is surfaced via the
+      // artifact + a workflow warning instead.
       verdict.set(r.id, 'ok');
     }
   }
@@ -178,6 +217,21 @@ function updateStreak(outDir: string, results: ProbeResult[]): void {
       streak[id] = (streak[id] ?? 0) + 1;
     } else {
       streak[id] = 0;
+    }
+  }
+
+  // Prune orphans: keys for anchors that no longer EXIST. `home.nameInput: 2`
+  // survived long after that anchor was dropped, and auto-heal iterates streak
+  // entries as candidates, so stale keys are noise in the one signal it reads.
+  //
+  // Keyed on the full UI_ANCHORS registry, NOT on this run's results: a run that
+  // skips the session phase (DESIGNER_PROBE_PROJECT_URL unset) produces no
+  // session.* results, and pruning on that would erase every live session streak.
+  const known = new Set(UI_ANCHORS.map((a) => a.id));
+  for (const id of Object.keys(streak)) {
+    if (!known.has(id)) {
+      console.log(`[ci-health] pruning orphan streak key ${id} (no longer a declared anchor)`);
+      delete streak[id];
     }
   }
 
@@ -338,6 +392,11 @@ async function main(): Promise<void> {
   const results: ProbeResult[] = [...homeResults, ...sessionResults];
   const counts = {
     ok: results.filter((r) => r.status === 'ok').length,
+    // `degraded` = working only via a superseded selector branch. Reported
+    // separately and deliberately NOT folded into `fail`: it must not open drift
+    // PRs or turn the run red (the tool still works), but it must never again be
+    // invisible the way a comma-OR fallback made it.
+    degraded: results.filter((r) => r.status === 'degraded').length,
     fail: results.filter((r) => r.status === 'fail').length,
     skip: results.filter((r) => r.status === 'skip').length
   };
@@ -363,7 +422,8 @@ async function main(): Promise<void> {
     doctor: {
       exitCode: doctor.exitCode,
       stdout: scrubArtifact(doctor.stdout),
-      stderr: scrubArtifact(doctor.stderr)
+      stderr: scrubArtifact(doctor.stderr),
+      spawnError: doctor.spawnError
     },
     health: {
       ok: !fail,
@@ -394,8 +454,22 @@ async function main(): Promise<void> {
   }
 
   // One-line summary for the workflow log.
-  const summary = `[ci-health] ${payload.ok ? 'OK' : 'FAIL'} — health ${counts.ok} ok / ${counts.fail} fail / ${counts.skip} skip · doctor exit ${doctor.exitCode} · v${payload.designerVersion}`;
+  const doctorSummary = doctor.spawnError ? `doctor DID NOT RUN (${doctor.spawnError})` : `doctor exit ${doctor.exitCode}`;
+  const summary = `[ci-health] ${payload.ok ? 'OK' : 'FAIL'} — health ${counts.ok} ok / ${counts.degraded} degraded / ${counts.fail} fail / ${counts.skip} skip · ${doctorSummary} · v${payload.designerVersion}`;
   console.log(summary);
+  if (counts.degraded > 0) {
+    const degraded = results.filter((r) => r.status === 'degraded');
+    console.log(
+      `::warning title=${counts.degraded} anchor(s) running on superseded selectors::${degraded.map((r) => r.id).join(', ')} — the canonical selector is gone; re-capture before the legacy branch goes too`
+    );
+    console.log(degraded.map((r) => `  ${r.id} — ${r.detail || r.description}`).join('\n'));
+  }
+  // A doctor that never launched is a broken probe, not a passing one. It does
+  // NOT flip `payload.ok` (that stays the UI-anchor verdict, so this can't start
+  // opening drift PRs for a tooling fault) — but it must never again be silent.
+  if (doctor.spawnError) {
+    console.log(`::warning title=designer doctor did not run::${doctor.spawnError} — the tooling-state half of this probe was skipped`);
+  }
   if (fail) {
     const failed = results.filter((r) => r.status === 'fail').map((r) => `  ${r.id} — ${r.detail || r.description}`);
     console.log(failed.join('\n'));
@@ -405,7 +479,15 @@ async function main(): Promise<void> {
   if (fail) process.exit(2);
 }
 
-main().catch((e: Error) => {
-  console.error(`[ci-health] threw: ${e.message}`);
-  process.exit(3);
-});
+// Only orchestrate when executed as a script. Without this guard, merely
+// IMPORTING this module (e.g. a unit test reaching for resolveDoctorBin) runs
+// the full probe: launches Chrome, drives claude.ai, and overwrites today's
+// artifact. Testability is the point — the doctor-path bug survived two months
+// partly because nothing here could be exercised without a browser.
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((e: Error) => {
+    console.error(`[ci-health] threw: ${e.message}`);
+    process.exit(3);
+  });
+}

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -108,6 +108,33 @@ function todayUtc(): string {
 export const scrubForTest = (s: string): string => scrubArtifact(s);
 
 /**
+ * Scrub EVERY string in a payload, recursively.
+ *
+ * The artifact used to be scrubbed field by field — `chromeUrl`, `canary`,
+ * `homeNav` and the `doctor` block each opted in by hand — so a field that
+ * forgot to opt in published raw. Two did: `diagnostics.url` and
+ * `health.results[].detail` both shipped unredacted project UUIDs (and the
+ * `?file=` query the scrubber exists to strip) in every world-downloadable
+ * artifact. Scrubbing the assembled payload instead makes redaction the
+ * DEFAULT, so the next field added is covered without anyone remembering.
+ *
+ * Safe over the whole tree: scrubArtifact is idempotent (verified across URL,
+ * home-path and already-scrubbed inputs), and it only rewrites UUID path
+ * segments, URL query/fragments, and home directories — none of which occur in
+ * the anchor `id` / `status` values auto-heal reads back out of this artifact.
+ */
+export function scrubDeep<T>(value: T): T {
+  if (typeof value === 'string') return scrubArtifact(value) as unknown as T;
+  if (Array.isArray(value)) return value.map(scrubDeep) as unknown as T;
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) out[k] = scrubDeep(v);
+    return out as unknown as T;
+  }
+  return value;
+}
+
+/**
  * The probe's verdict, as three distinct outcomes rather than a boolean.
  *
  *   ok         — anchors green AND the tooling half actually ran
@@ -514,7 +541,9 @@ async function main(): Promise<void> {
   const outDir = path.join(REPO_ROOT, 'artifacts', 'health');
   ensureDir(outDir);
   const outFile = path.join(outDir, artifactName);
-  fs.writeFileSync(outFile, JSON.stringify(payload, null, 2));
+  // Single privacy boundary: everything published goes through the scrubber
+  // here, rather than each field opting in individually upstream.
+  fs.writeFileSync(outFile, JSON.stringify(scrubDeep(payload), null, 2));
 
   // Streak tracker — input to the auto-heal workflow's N=2 gate. Dedups
   // across phases (a pattern.* anchor probed in both home + session counts

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -76,7 +76,14 @@ function runDoctor(): DoctorRun {
     // A failure to LAUNCH is not an exit code. Keep it distinguishable in the
     // artifact so "never ran" can never again read the same as "ran and was
     // unhappy" — that ambiguity is what hid this bug for two months.
-    spawnError: r.error ? `${(r.error as NodeJS.ErrnoException).code ?? 'ERROR'}: ${r.error.message}` : null
+    //
+    // Scrubbed HERE rather than at payload-assembly time, because Node embeds the
+    // absolute executable path in spawn errors ("spawnSync /Users/<name>/.../bin/
+    // designer ENOENT") and this string reaches THREE public sinks: the
+    // world-downloadable artifact, the run summary line, and the ::warning
+    // annotation. Scrubbing only the artifact would leak the runner's username
+    // into the workflow log instead — exactly in the failure case this records.
+    spawnError: r.error ? scrubArtifact(`${(r.error as NodeJS.ErrnoException).code ?? 'ERROR'}: ${r.error.message}`) : null
   };
 }
 
@@ -97,6 +104,9 @@ function todayUtc(): string {
 // strings + fragments from URLs, and replace absolute home-dir paths with a
 // stable token so reading the artifact later still tells a maintainer
 // "doctor saw <something under home>" without exposing the username.
+/** Test seam: the scrubber is the privacy boundary, so it is asserted directly. */
+export const scrubForTest = (s: string): string => scrubArtifact(s);
+
 function scrubArtifact(s: string): string {
   if (!s) return s;
   return s

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -127,8 +127,18 @@ export function probeVerdict(input: { anchorFail: boolean; doctorSpawnError: str
   // Anchor drift wins: it is the signal the drift PR exists to carry, and it is
   // actionable even when the toolchain is also unhappy.
   if (input.anchorFail) return 'drift';
+  // ONLY a failure to launch means the probe did not run. A non-zero doctor exit
+  // deliberately does NOT gate.
+  //
+  // `designer doctor` exits 2 if ANY of its checks fails, several of which are
+  // orthogonal to whether this probe is valid — and one fires routinely: doctor
+  // runs BEFORE the probe navigates, and ensureCdp() may have just relaunched
+  // Chrome, so the "claude.ai/design tab" check (status 'fail') sees a browser
+  // with no design tab yet. Gating on the exit code would therefore fail the
+  // daily job on ordinary runs and permanently block `Close stale drift PRs on
+  // green`, turning a diagnostic into an outage. A non-zero exit is surfaced via
+  // the artifact + an ::error annotation instead; it is information, not a gate.
   if (input.doctorSpawnError !== null) return 'incomplete';
-  if (input.doctorExitCode !== 0) return 'incomplete';
   return 'ok';
 }
 

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -587,6 +587,12 @@ async function main(): Promise<void> {
   }
   console.log(`[ci-health] wrote ${path.relative(REPO_ROOT, outFile)}`);
 
+  // Published so the workflow can refuse to close a drift PR while anchors are
+  // running on superseded selectors. Deliberately NOT folded into the verdict:
+  // degraded means the tool still works, and making it non-`ok` would fail the
+  // daily job for a working system — the same trap as gating on doctor's exit
+  // code. It withholds the green-only cleanup action instead.
+  ghOutput('degraded', String(counts.degraded));
   const verdict = probeVerdict({
     anchorFail: fail,
     doctorSpawnError: doctor.spawnError,

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -10,7 +10,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { createBrowser, type Browser } from '../browser.ts';
 import { runHealth, UI_ANCHORS, type ProbeResult } from '../ui-anchors.ts';
 import { REPO_ROOT } from '../repo-root.ts';
@@ -206,8 +206,15 @@ function scrubArtifact(s: string): string {
     // Strip query strings and fragments from URLs (claude.ai/design?file=foo).
     .replace(/(https?:\/\/[^\s?#]+)[?#][^\s]*/g, '$1')
     // macOS home dirs (/Users/<name>/...) and Linux (/home/<name>/...).
-    .replace(/\/Users\/[^\/\s]+/g, '/Users/<redacted>')
-    .replace(/\/home\/[^\/\s]+/g, '/home/<redacted>');
+    // Two passes per platform: the first handles usernames CONTAINING SPACES by
+    // consuming up to the next path separator (a macOS full-name home like
+    // "/Users/Provi Last/…" otherwise leaked the surname, since [^/\s] stops at
+    // the space). It requires a following '/' so it cannot run away over prose.
+    // The second catches the trailing-segment form with no following slash.
+    .replace(/\/Users\/[^\/\n"]+?(?=\/)/g, '/Users/<redacted>')
+    .replace(/\/home\/[^\/\n"]+?(?=\/)/g, '/home/<redacted>')
+    .replace(/\/Users\/[^\/\s"]+/g, '/Users/<redacted>')
+    .replace(/\/home\/[^\/\s"]+/g, '/home/<redacted>');
 }
 
 function scrubNav(n: { target: string; landedOn: string; error?: string } | null): typeof n {
@@ -608,7 +615,12 @@ async function main(): Promise<void> {
 // the full probe: launches Chrome, drives claude.ai, and overwrites today's
 // artifact. Testability is the point — the doctor-path bug survived two months
 // partly because nothing here could be exercised without a browser.
-const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+// realpath BOTH sides: import.meta.url is already resolved through symlinks, so
+// comparing it to a raw argv[1] makes the guard silently false under a symlinked
+// checkout (or an npm-linked bin) — the script would then be imported-but-never-run.
+// Latent today (both workflows invoke by relative path), cheap to make robust.
+const entry = process.argv[1] ? fs.realpathSync(process.argv[1]) : '';
+const invokedDirectly = entry !== '' && fs.realpathSync(fileURLToPath(import.meta.url)) === entry;
 if (invokedDirectly) {
   main().catch((e: Error) => {
     console.error(`[ci-health] threw: ${e.message}`);

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -144,6 +144,22 @@ function ghOutput(key: string, value: string): void {
   fs.appendFileSync(target, `${key}=${value}\n`);
 }
 
+/**
+ * The ONLY way this script may terminate. Every exit publishes a verdict first.
+ *
+ * The workflow gates on `verdict`, so an exit path that skips it leaves the
+ * output unset — and with `continue-on-error: true` on the probe step, all three
+ * gates then evaluate false and the job finishes GREEN. Routing every exit
+ * through here is what keeps "the probe died early" from reading as "the probe
+ * passed". `code` defaults to the verdict's canonical exit code; the throw path
+ * overrides it to keep 3 distinguishable in logs.
+ */
+function exitWith(verdict: ProbeVerdict, code: number = EXIT_CODE[verdict]): never {
+  ghOutput('verdict', verdict);
+  console.log(`[ci-health] verdict=${verdict}`);
+  process.exit(code);
+}
+
 function scrubArtifact(s: string): string {
   if (!s) return s;
   return s
@@ -383,7 +399,11 @@ async function main(): Promise<void> {
     ensureDir(outDir);
     fs.writeFileSync(path.join(outDir, artifactName), JSON.stringify(payload, null, 2));
     console.error(`[ci-health] FAIL — CDP unreachable on :${CDP_PORT} (${cdp.detail}); restart attempted=${cdp.attemptedRestart}`);
-    process.exit(2);
+    // `incomplete`, not `drift`: Chrome being unreachable is an environment
+    // fault and must never be filed as a claude.ai redesign — the same stance
+    // the workflow's preflight step already takes. Previously this exited 2,
+    // which opened a selectors-drift PR for a dead browser.
+    exitWith('incomplete');
   }
   console.log(`[ci-health] CDP alive — ${cdp.detail}${cdp.attemptedRestart ? ' (restarted)' : ''}`);
 
@@ -535,9 +555,7 @@ async function main(): Promise<void> {
   });
   // The workflow gates on this, not on the raw step outcome — `outcome` only has
   // success/failure, which cannot separate "UI drifted" from "probe broke".
-  ghOutput('verdict', verdict);
-  console.log(`[ci-health] verdict=${verdict}`);
-  if (verdict !== 'ok') process.exit(EXIT_CODE[verdict]);
+  exitWith(verdict);
 }
 
 // Only orchestrate when executed as a script. Without this guard, merely
@@ -549,6 +567,10 @@ const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(pro
 if (invokedDirectly) {
   main().catch((e: Error) => {
     console.error(`[ci-health] threw: ${e.message}`);
-    process.exit(3);
+    // An exception means the probe did not finish, so the workflow must see
+    // `incomplete` rather than an unset verdict (which would gate to green).
+    // Exit code stays 3 so "threw" remains distinguishable from a clean
+    // incomplete verdict in the logs.
+    exitWith('incomplete', 3);
   });
 }

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -107,6 +107,43 @@ function todayUtc(): string {
 /** Test seam: the scrubber is the privacy boundary, so it is asserted directly. */
 export const scrubForTest = (s: string): string => scrubArtifact(s);
 
+/**
+ * The probe's verdict, as three distinct outcomes rather than a boolean.
+ *
+ *   ok         — anchors green AND the tooling half actually ran
+ *   drift      — UI anchors regressed; this is the selectors-drift-PR path
+ *   incomplete — the probe could not fully run (doctor never launched, or
+ *                reported a broken toolchain). NOT drift: opening a drift PR for
+ *                it would misfile a tooling fault as a claude.ai redesign.
+ *
+ * Exists because a two-state exit code forced a false choice: exit 0 let a
+ * half-broken probe read as green (and `Close stale drift PRs on green` would
+ * then close a legitimate open drift PR), while exit 2 would have misclassified
+ * it as UI drift. The workflow gates on this value, not on the raw step outcome.
+ */
+export type ProbeVerdict = 'ok' | 'drift' | 'incomplete';
+
+export function probeVerdict(input: { anchorFail: boolean; doctorSpawnError: string | null; doctorExitCode: number }): ProbeVerdict {
+  // Anchor drift wins: it is the signal the drift PR exists to carry, and it is
+  // actionable even when the toolchain is also unhappy.
+  if (input.anchorFail) return 'drift';
+  if (input.doctorSpawnError !== null) return 'incomplete';
+  if (input.doctorExitCode !== 0) return 'incomplete';
+  return 'ok';
+}
+
+/** Exit codes: 0 ok · 2 drift · 3 threw (main().catch) · 4 incomplete. */
+export const EXIT_CODE: Record<ProbeVerdict, number> = { ok: 0, drift: 2, incomplete: 4 };
+
+function ghOutput(key: string, value: string): void {
+  const target = process.env.GITHUB_OUTPUT;
+  if (!target) {
+    console.log(`[ci-health] (no GITHUB_OUTPUT) ${key}=${value}`);
+    return;
+  }
+  fs.appendFileSync(target, `${key}=${value}\n`);
+}
+
 function scrubArtifact(s: string): string {
   if (!s) return s;
   return s
@@ -474,11 +511,16 @@ async function main(): Promise<void> {
     );
     console.log(degraded.map((r) => `  ${r.id} — ${r.detail || r.description}`).join('\n'));
   }
-  // A doctor that never launched is a broken probe, not a passing one. It does
-  // NOT flip `payload.ok` (that stays the UI-anchor verdict, so this can't start
-  // opening drift PRs for a tooling fault) — but it must never again be silent.
+  // A doctor that never launched is a broken probe, not a passing one. It still
+  // does NOT flip `payload.ok` (that stays the UI-anchor verdict, so a tooling
+  // fault can never open a selectors-drift PR) — instead it produces the
+  // `incomplete` verdict below, which is a THIRD workflow path. An annotation
+  // alone does not change a step's outcome, so warning-only left a half-broken
+  // probe reading as green to `Close stale drift PRs on green`.
   if (doctor.spawnError) {
-    console.log(`::warning title=designer doctor did not run::${doctor.spawnError} — the tooling-state half of this probe was skipped`);
+    console.log(`::error title=designer doctor did not run::${doctor.spawnError} — the tooling-state half of this probe was skipped`);
+  } else if (doctor.exitCode !== 0) {
+    console.log(`::error title=designer doctor reported a broken toolchain::exit ${doctor.exitCode} — see the doctor block in the health artifact`);
   }
   if (fail) {
     const failed = results.filter((r) => r.status === 'fail').map((r) => `  ${r.id} — ${r.detail || r.description}`);
@@ -486,7 +528,16 @@ async function main(): Promise<void> {
   }
   console.log(`[ci-health] wrote ${path.relative(REPO_ROOT, outFile)}`);
 
-  if (fail) process.exit(2);
+  const verdict = probeVerdict({
+    anchorFail: fail,
+    doctorSpawnError: doctor.spawnError,
+    doctorExitCode: doctor.exitCode
+  });
+  // The workflow gates on this, not on the raw step outcome — `outcome` only has
+  // success/failure, which cannot separate "UI drifted" from "probe broke".
+  ghOutput('verdict', verdict);
+  console.log(`[ci-health] verdict=${verdict}`);
+  if (verdict !== 'ok') process.exit(EXIT_CODE[verdict]);
 }
 
 // Only orchestrate when executed as a script. Without this guard, merely

--- a/selectors.json
+++ b/selectors.json
@@ -1,21 +1,31 @@
 {
   "_notes": "Captured 2026-04-17 from Chrome 147 via CDP. Override at ~/.designer/selectors.override.json. Prefer data-testid over class names — Claude's styled-components classes (sc-xxx) are regenerated on every build.",
-  "_drift": "2026-07 re-drifted, re-captured live 2026-07-24 from Chrome 150 (signed-in profile). The home is STILL composer-driven, but every home selector that was keyed on a tag name or a visible label has moved onto a data-testid — so this capture keys on testids only. Changes vs the 2026-06 capture: (1) the composer is no longer a <textarea> at all — the home now renders ZERO textareas; it is a ProseMirror contenteditable <div data-testid=\"home-composer-input\">. _submitPrompt's contenteditable branch (synthetic paste) drives it. (2) The submit button gained data-testid=\"home-composer-send\"; it is the SAME element as button[title=\"Create\"], which is kept as a fallback. It is always enabled, so content — not enabled-ness — is the submit gate. (3) The creation-type cards moved to data-testid=\"carousel-type-<kind>\" and their LABELS churn independently ('Product prototype' → 'Prototype' → 'Mobile app design' across three captures) — key on the testid, never the label. The testids survived every rename. (4) Projects moved from a flat link list to a <section data-testid=\"projects-list\"> of <tr data-testid=\"project-row\">; the row's <a href=/design/p/<uuid>> is now an EMPTY overlay link — the name lives in the first <td> and on the anchor's aria-label, so listProjects must not read anchor text. Placeholder text still ROTATES ('Draft a one-page project brief', …) — never key a selector on it. `designer adopt` remains available to bind an already-open tab to a key.",
+  "_drift": "2026-07 re-drifted, re-captured live 2026-07-24 from Chrome 150 (signed-in profile). The home is STILL composer-driven, but every home selector that was keyed on a tag name or a visible label has moved onto a data-testid — so this capture keys on testids only. Changes vs the 2026-06 capture: (1) the composer is no longer a <textarea> at all — the home now renders ZERO textareas; it is a ProseMirror contenteditable <div data-testid=\"home-composer-input\">. _submitPrompt's contenteditable branch (synthetic paste) drives it. (2) The submit button gained data-testid=\"home-composer-send\"; it is the SAME element as button[title=\"Create\"], which is retained as a LEGACY branch in `homeLegacy` (see `_branches` — a comma-OR is not an ordered fallback). It is always enabled, so content — not enabled-ness — is the submit gate. (3) The creation-type cards moved to data-testid=\"carousel-type-<kind>\" and their LABELS churn independently ('Product prototype' → 'Prototype' → 'Mobile app design' across three captures) — key on the testid, never the label. The testids survived every rename. (4) Projects moved from a flat link list to a <section data-testid=\"projects-list\"> of <tr data-testid=\"project-row\">; the row's <a href=/design/p/<uuid>> is now an EMPTY overlay link — the name lives in the first <td> and on the anchor's aria-label, so listProjects must not read anchor text. Placeholder text still ROTATES ('Draft a one-page project brief', …) — never key a selector on it. `designer adopt` remains available to bind an already-open tab to a key.",
   "_urls": {
     "home": "https://claude.ai/design",
     "session": "https://claude.ai/design/p/{uuid}"
   },
+  "_branches": "A comma-separated CSS list is NOT an ordered fallback. `document.querySelector('A, B')` returns the first element in DOCUMENT ORDER matching either branch — not A's match preferred over B's. Packing a legacy branch into a canonical selector therefore (1) can silently return the WRONG element at runtime, and (2) keeps a presence-only health anchor green after the canonical selector has rotted, which defeats the daily probe. So canonical selectors below are single-branch, and superseded forms live in `homeLegacy` / `loginLegacy`. Health checks canonical first and reports `degraded` (not `ok`) when only the legacy branch matches; runtime resolvers try them in explicit order.",
   "login": {
-    "signedInIndicator": "[data-testid=\"chat-composer-input\"], [data-testid=\"home-composer-input\"], button[title=\"Create\"]"
+    "signedInIndicator": "[data-testid=\"chat-composer-input\"], [data-testid=\"home-composer-input\"]"
+  },
+  "loginLegacy": {
+    "signedInIndicator": "button[title=\"Create\"]"
   },
   "home": {
     "creator": "[data-testid=\"home-composer-input\"]",
     "nameInput": "[data-testid=\"home-composer-input\"]",
     "wireframeButton": "[data-testid=\"carousel-type-wireframe\"]",
     "highFiButton": "[data-testid=\"carousel-type-prototype\"]",
-    "createButton": "[data-testid=\"home-composer-send\"], button[title=\"Create\"]",
-    "projectsList": "[data-testid=\"projects-list\"], a[href*=\"/design/p/\"]",
-    "projectCard": "[data-testid=\"project-row\"], a[href*=\"/design/p/\"]"
+    "createButton": "[data-testid=\"home-composer-send\"]",
+    "projectsList": "[data-testid=\"projects-list\"]",
+    "projectCard": "[data-testid=\"project-row\"]",
+    "projectLink": "a[href*=\"/design/p/\"]"
+  },
+  "homeLegacy": {
+    "createButton": "button[title=\"Create\"]",
+    "projectsList": "a[href*=\"/design/p/\"]",
+    "projectCard": "a[href*=\"/design/p/\"]"
   },
   "composer": {
     "promptTextarea": "[data-testid=\"chat-composer-input\"]",

--- a/selectors.json
+++ b/selectors.json
@@ -29,10 +29,13 @@
   },
   "composer": {
     "promptTextarea": "[data-testid=\"chat-composer-input\"]",
-    "sendButton": "[data-testid=\"chat-send-button\"], button[title^=\"Send (\"]",
+    "sendButton": "[data-testid=\"chat-send-button\"]",
     "stopButton": null,
     "attachButton": "button[aria-label=\"Attach file\"]",
     "modelButton": "[data-testid=\"model-selector-button\"]"
+  },
+  "composerLegacy": {
+    "sendButton": "button[title^=\"Send (\"]"
   },
   "preview": {
     "iframeOrContainer": "[data-testid=\"html-viewer-iframe\"]",

--- a/selectors.ts
+++ b/selectors.ts
@@ -12,8 +12,20 @@ import { REPO_ROOT } from './repo-root.ts';
 // independently in each file, which drifted apart on every claude.ai redesign
 // (e.g. login.signedIn kept probing a chat-composer-input testid the home had
 // dropped). Keep DOM selectors in selectors.json, not inline literals.
+// Canonical vs legacy. A comma-separated CSS list is not an ordered fallback —
+// `querySelector('A, B')` returns whichever matches first in DOCUMENT ORDER. So
+// canonical entries stay single-branch and superseded forms live in the
+// `*Legacy` blocks, resolved explicitly and in order (see resolveBranches).
+// This keeps a health anchor from staying green on the legacy branch after the
+// canonical selector has rotted.
 export interface Selectors {
   login: { signedInIndicator: string | null };
+  loginLegacy?: { signedInIndicator?: string | null };
+  homeLegacy?: {
+    createButton?: string;
+    projectsList?: string;
+    projectCard?: string;
+  };
   home: {
     creator: string;
     nameInput: string;
@@ -25,7 +37,10 @@ export interface Selectors {
     highFiButton: string;
     createButton: string;
     projectsList: string;
+    /** The project ROW container (canonical). */
     projectCard: string;
+    /** The per-project link carrying the /design/p/<uuid> href. */
+    projectLink: string;
   };
   composer: {
     promptTextarea: string;
@@ -71,6 +86,25 @@ function loadSelectors(): Selectors {
     }
   }
   return base;
+}
+
+/**
+ * Canonical-first, legacy-second, as an ORDERED list. Use when the caller acts
+ * on the element (clicks it, fills it) — `querySelector('A, B')` would return
+ * whichever is first in document order, which is not necessarily the canonical
+ * one, and a stale duplicate could win.
+ */
+export function orderedBranches(canonical: string, legacy?: string | null): string[] {
+  return legacy && legacy !== canonical ? [canonical, legacy] : [canonical];
+}
+
+/**
+ * Canonical + legacy joined for a PRESENCE-only test ("is any of these here?").
+ * Safe precisely because the caller does not care which element comes back.
+ * Never use this to pick an element to act on — see orderedBranches.
+ */
+export function presenceSelector(canonical: string | null | undefined, legacy?: string | null): string {
+  return [canonical, legacy].filter(Boolean).join(', ');
 }
 
 let _cached: Selectors | null = null;

--- a/selectors.ts
+++ b/selectors.ts
@@ -26,6 +26,7 @@ export interface Selectors {
     projectsList?: string;
     projectCard?: string;
   };
+  composerLegacy?: { sendButton?: string };
   home: {
     creator: string;
     nameInput: string;

--- a/setup.ts
+++ b/setup.ts
@@ -6,7 +6,7 @@ import { createHash } from 'node:crypto';
 import { REPO_ROOT } from './repo-root.ts';
 import { defaultChromeBin, isChromeRunning, xspawnSync, WHICH, IS_WIN, QUIT_CHROME_HINT } from './cross-platform.ts';
 import { createBrowser, type Browser } from './browser.ts';
-import { getSelectors } from './selectors.ts';
+import { getSelectors, presenceSelector } from './selectors.ts';
 
 const SKILL_SRC = path.join(REPO_ROOT, 'skills', 'designer-loop', 'SKILL.md');
 const SKILL_DEST_DIR = path.join(os.homedir(), '.claude', 'skills', 'designer-loop');
@@ -47,7 +47,10 @@ async function verifySignedIn(browser: Browser): Promise<boolean> {
   // from the single source so a home redesign updates it in one place: the prior
   // inline copy (`project-creator`/`chat-composer-input`) went stale when the home
   // dropped those testids, so setup false-negated sign-in on the redesigned home.
-  const sel = getSelectors().login.signedInIndicator;
+  // Presence-only test, so canonical + legacy may be probed as one list — we
+  // only care THAT a marker is present, never which element comes back.
+  const s = getSelectors();
+  const sel = presenceSelector(s.login.signedInIndicator, s.loginLegacy?.signedInIndicator);
   if (!sel) return false;
   const js = `!!document.querySelector(${JSON.stringify(sel)})`;
   return browser.evalValue<boolean>(js).catch(() => false);

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -453,3 +453,46 @@ test('project names are chosen by source priority, not string length', () => {
   assert.ok(!/sort\(\(x, y\) => x\.length - y\.length\)/.test(scrape), 'shortest-wins heuristic is back');
   assert.match(scrape, /NAME_SOURCES = \['rowCell', 'ariaLabel', 'anchorText'\]/, 'source priority order changed');
 });
+
+// --- Seam 1: redaction is the default, not per-field opt-in ---
+
+const LEAK_UUID = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+
+test('scrubDeep redacts the fields that shipped raw (diagnostics.url, results[].detail)', async () => {
+  const { scrubDeep } = await import('../scripts/ci-health.ts');
+  // Shape lifted from a REAL published artifact (health/drift-2026-07-24) that
+  // leaked a project UUID in both of these fields.
+  const payload = {
+    diagnostics: { url: 'https://claude.ai/design/p/6c5115ec-b27c-46b8-a7d9-1b09df042eff?file=index.html', htmlBytes: 68796 },
+    health: {
+      results: [
+        { id: 'pattern.sessionUrl', status: 'ok', detail: 'url=https://claude.ai/design/p/6c5115ec-b27c-46b8-a7d9-1b09df042eff?file=index.html' }
+      ]
+    }
+  };
+  const out = scrubDeep(payload);
+  assert.doesNotMatch(JSON.stringify(out), LEAK_UUID, 'a project UUID survived the publish boundary');
+  assert.doesNotMatch(out.diagnostics.url, /\?file=/, 'query string must be stripped');
+  // Conservation: auto-heal keys on these, so scrubbing must not touch them.
+  assert.equal(out.health.results[0].id, 'pattern.sessionUrl');
+  assert.equal(out.health.results[0].status, 'ok');
+  assert.equal(out.diagnostics.htmlBytes, 68796, 'non-string values must pass through');
+});
+
+test('scrubDeep covers a field nobody remembered to opt in', async () => {
+  const { scrubDeep } = await import('../scripts/ci-health.ts');
+  // The point of the seam: a NEW field is redacted without being wired up.
+  const out = scrubDeep({ someFutureField: { nested: ['/Users/alice/x', 'https://claude.ai/design/p/6c5115ec-b27c-46b8-a7d9-1b09df042eff'] } });
+  assert.doesNotMatch(JSON.stringify(out), LEAK_UUID);
+  assert.doesNotMatch(JSON.stringify(out), /\/Users\/(?!<redacted>)[^/"\s]+/);
+});
+
+test('scrubDeep is safe on the degenerate shapes (null diagnostics, empty results)', async () => {
+  const { scrubDeep } = await import('../scripts/ci-health.ts');
+  assert.deepEqual(scrubDeep({ diagnostics: null, health: { results: [] } }), { diagnostics: null, health: { results: [] } });
+});
+
+test('the artifact is written through the scrubber, not the raw payload', () => {
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/ci-health.ts'), 'utf8');
+  assert.match(src, /writeFileSync\(outFile, JSON\.stringify\(scrubDeep\(payload\)/, 'the write boundary must scrub');
+});

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -276,8 +276,16 @@ test('a doctor that never launched is incomplete, NOT green and NOT drift', () =
   assert.notEqual(v, 'drift');
 });
 
-test('a doctor that ran but reported a broken toolchain is incomplete', () => {
-  assert.equal(probeVerdict({ anchorFail: false, doctorSpawnError: null, doctorExitCode: 2 }), 'incomplete');
+test('a NON-ZERO doctor exit does not gate the workflow', () => {
+  // Deliberate. doctor exits 2 if any of its checks fails, and one fires on
+  // ordinary runs: doctor runs before the probe navigates, and ensureCdp() may
+  // have just relaunched Chrome, so the "claude.ai/design tab" check sees no
+  // design tab. Gating here would fail the daily job routinely and permanently
+  // block `Close stale drift PRs on green` — a diagnostic becoming an outage.
+  assert.equal(probeVerdict({ anchorFail: false, doctorSpawnError: null, doctorExitCode: 2 }), 'ok');
+  // A failure to LAUNCH is still incomplete — that is the case where the
+  // tooling half genuinely did not run.
+  assert.equal(probeVerdict({ anchorFail: false, doctorSpawnError: 'ENOENT: ...', doctorExitCode: -1 }), 'incomplete');
 });
 
 test('anchor drift outranks a broken doctor — the actionable signal wins', () => {

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -496,3 +496,61 @@ test('the artifact is written through the scrubber, not the raw payload', () => 
   const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/ci-health.ts'), 'utf8');
   assert.match(src, /writeFileSync\(outFile, JSON\.stringify\(scrubDeep\(payload\)/, 'the write boundary must scrub');
 });
+
+// --- Theme A: enforce the selector contract over ALL of selectors.json ---
+// The prior guard iterated `sel.home` only, so login.*, composer.*, preview.*
+// and messages.* were unguarded — and a live violation was sitting in
+// composer.sendButton, whose two branches ui-anchors.ts itself documents as
+// canonical + superseded.
+
+// Values allowed to contain a comma, with the reason. A comma is otherwise a
+// packed canonical+legacy pair, which querySelector resolves by document order.
+const MULTI_BRANCH_OK = {
+  'login.signedInIndicator':
+    'genuine cross-surface disjunction (in-session composer OR home composer), not canonical+legacy — and presence-only, so which one matches is irrelevant'
+};
+
+// Selector keys with no ui-anchors.ts anchor, with the reason each is exempt.
+// Anything NOT listed here must be anchored: an unanchored selector on a scrape
+// path is how `home.projectLink` drove listProjects with the probe blind to it.
+const UNANCHORED_OK = {
+  'composer.stopButton': 'null in the current capture — nothing to probe',
+  'composer.attachButton': 'not on any scrape path; unused affordance',
+  'composer.modelButton': 'not on any scrape path; unused affordance',
+  'preview.exportButtonText': 'label text, not a selector; share.shareButton covers the surface',
+  'preview.shareButtonText': 'label text, not a selector; share.shareButton covers the surface',
+  'preview.emptyStateHeading': 'label text used for an empty-state assertion, not a probe',
+  'messages.generatingIndicator': 'null in the current capture — nothing to probe',
+  'interstitials.continueHere': 'button label; interstitials.ts owns detection and is unit-tested'
+};
+
+const selectorGroups = () => {
+  const sel = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'selectors.json'), 'utf8'));
+  return Object.entries(sel).filter(([g, v]) => !g.startsWith('_') && v && typeof v === 'object');
+};
+
+test('no selector packs multiple branches into one comma-OR value', () => {
+  const offenders = [];
+  for (const [group, entries] of selectorGroups()) {
+    for (const [k, v] of Object.entries(entries)) {
+      if (k.startsWith('_') || typeof v !== 'string') continue;
+      const key = `${group}.${k}`;
+      if (v.includes(',') && !MULTI_BRANCH_OK[key]) offenders.push(`${key} = ${v}`);
+    }
+  }
+  assert.deepEqual(offenders, [], `packed comma-OR selectors (document-order hazard + masks degraded): ${offenders.join(' | ')}`);
+});
+
+test('every selector is either anchored in ui-anchors.ts or explicitly exempt', () => {
+  // Normalize optional chaining so `SEL.homeLegacy?.createButton` counts.
+  const anchors = fs.readFileSync(path.join(REPO_ROOT, 'ui-anchors.ts'), 'utf8').replace(/\?\./g, '.');
+  const unanchored = [];
+  for (const [group, entries] of selectorGroups()) {
+    for (const k of Object.keys(entries)) {
+      if (k.startsWith('_')) continue;
+      const key = `${group}.${k}`;
+      if (!anchors.includes(key) && !UNANCHORED_OK[key]) unanchored.push(key);
+    }
+  }
+  assert.deepEqual(unanchored, [], `selectors with no health anchor and no documented exemption: ${unanchored.join(', ')}`);
+});

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -200,21 +200,42 @@ test('no canonical selector smuggles a comma-OR legacy branch back in', () => {
 
 // --- PR #131 review (Codex P2 x2) ---
 
-test('doctor spawnError is scrubbed of the runner home path before it is published', async () => {
+// A home dir survives scrubbing only as the literal `<redacted>` token.
+const LEAKED_MACOS = /\/Users\/(?!<redacted>)[^/\s]+/;
+const LEAKED_LINUX = /\/home\/(?!<redacted>)[^/\s]+/;
+
+test('the scrubber redacts home-dir paths in spawn errors', async () => {
   // Node embeds the absolute executable path in spawn errors. The health
-  // artifact is a world-downloadable public-repo artifact for 30 days, and the
-  // same string also reaches the run summary + a ::warning annotation, so the
-  // scrub has to happen at the source, not at payload-assembly time.
+  // artifact is world-downloadable for 30 days, and the same string also reaches
+  // the run summary + a ::warning annotation, so the scrub happens at the source.
+  //
+  // Synthetic inputs on purpose: asserting against THIS checkout's real path
+  // would make the test pass or fail on where the repo happens to live (it would
+  // fail outright in a /workspace or Windows checkout), which is the
+  // green-by-accident failure this whole PR is about.
+  const { scrubForTest } = await import('../scripts/ci-health.ts');
+  for (const raw of [
+    'ENOENT: spawnSync /Users/alice/dev/designer/bin/designer ENOENT',
+    'ENOENT: spawnSync /home/runner/work/designer/designer/bin/designer ENOENT'
+  ]) {
+    const scrubbed = scrubForTest(raw);
+    assert.doesNotMatch(scrubbed, LEAKED_MACOS, `macOS username leaked from: ${raw}`);
+    assert.doesNotMatch(scrubbed, LEAKED_LINUX, `Linux username leaked from: ${raw}`);
+    assert.match(scrubbed, /ENOENT/, 'scrubbing must preserve the diagnostic');
+  }
+});
+
+test('a real spawn failure is publishable — no unredacted home dir, whatever the checkout path', async () => {
   const { spawnSync } = await import('node:child_process');
   const r = spawnSync(path.join(REPO_ROOT, 'bin', 'designer'), ['doctor']);
   assert.ok(r.error, 'expected ENOENT for the extensionless path');
-  assert.match(r.error.message, /\/Users\/|\/home\//, 'precondition: raw message carries a home path');
-
+  // No precondition on the raw message's shape — the invariant is about what
+  // gets PUBLISHED, and it must hold from any checkout location.
   const { scrubForTest } = await import('../scripts/ci-health.ts');
-  const scrubbed = scrubForTest(`${r.error.code}: ${r.error.message}`);
-  assert.doesNotMatch(scrubbed, /\/Users\/(?!<redacted>)[^/\s]+/, 'macOS username leaked');
-  assert.doesNotMatch(scrubbed, /\/home\/(?!<redacted>)[^/\s]+/, 'Linux username leaked');
-  assert.match(scrubbed, /ENOENT/, 'scrubbing must preserve the diagnostic');
+  const published = scrubForTest(`${r.error.code}: ${r.error.message}`);
+  assert.doesNotMatch(published, LEAKED_MACOS, 'macOS username leaked');
+  assert.doesNotMatch(published, LEAKED_LINUX, 'Linux username leaked');
+  assert.match(published, /ENOENT/, 'scrubbing must preserve the diagnostic');
 });
 
 test('every ProbeStatus is rendered distinctly by the CLI health reporter', () => {

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -282,11 +282,13 @@ test('a doctor that never launched is incomplete, NOT green and NOT drift', () =
 });
 
 test('a NON-ZERO doctor exit does not gate the workflow', () => {
-  // Deliberate. doctor exits 2 if any of its checks fails, and one fires on
-  // ordinary runs: doctor runs before the probe navigates, and ensureCdp() may
-  // have just relaunched Chrome, so the "claude.ai/design tab" check sees no
-  // design tab. Gating here would fail the daily job routinely and permanently
-  // block `Close stale drift PRs on green` — a diagnostic becoming an outage.
+  // Deliberate, on reproduced evidence: doctor run against a CDP Chrome with no
+  // design tab exits 0 (that check is 'warn', not 'fail'). Of doctor's six real
+  // 'fail' branches only MCP-registration is orthogonal to probe validity, and
+  // the rest are already covered — signed-out fails login.signedIn (-> drift),
+  // a missing selectors.json/agent-browser makes the probe throw (-> incomplete).
+  // Gating on the exit code therefore buys ~nothing and risks blocking stale-PR
+  // cleanup on an unrelated Claude Code registration fault.
   assert.equal(probeVerdict({ anchorFail: false, doctorSpawnError: null, doctorExitCode: 2 }), 'ok');
   // A failure to LAUNCH is still incomplete — that is the case where the
   // tooling half genuinely did not run.

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -625,3 +625,20 @@ test('idOf admits a trailing slash but still rejects project subroutes', () => {
   assert.ok(re.test(`/design/p/${uuid}/`), 'trailing slash must match (#F8)');
   assert.ok(!re.test(`/design/p/${uuid}/settings`), 'subroutes must NOT match — they become phantom projects');
 });
+
+test('the turn-RPC canary resolves the send button through both branches', () => {
+  // Residual found sweeping my own #F1 fix: splitting composer.sendButton into
+  // canonical + legacy left the canary querying the CANONICAL selector raw —
+  // and ui-anchors itself records that data-testid="chat-send-button" was
+  // dropped in the 2026-06 build, so the canary would have found nothing.
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'ui-anchors.ts'), 'utf8');
+  const start = src.indexOf('async function submitTurnRpcCanary');
+  const end = src.indexOf('async function checkTurnRpcContract');
+  assert.ok(start > 0 && end > start, 'canary bounds not found — update this test');
+  const canary = src.slice(start, end);
+  assert.ok(
+    !/querySelector\(\$\{JSON\.stringify\(SEL\.composer\.sendButton\)\}\)/.test(canary),
+    'canary still queries the canonical send button raw — it would miss the live legacy branch'
+  );
+  assert.match(canary, /SEND_BRANCHES_JSON/, 'canary must resolve ordered branches');
+});

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { resolveDoctorBin } from '../scripts/ci-health.ts';
+import { findAnchor, canPatch } from '../scripts/anchor-patcher.ts';
+import { classifyCandidates, isStructurallyBlind, patchableAnchorIds } from '../scripts/auto-heal.ts';
+import { orderedBranches, presenceSelector } from '../selectors.ts';
+import { UI_ANCHORS } from '../ui-anchors.ts';
+import { REPO_ROOT } from '../repo-root.ts';
+
+// Regression coverage for the 2026-07-25 audit: three layers of the health
+// apparatus each reported success while asserting nothing.
+//   * ci-health spawned `bin/designer`, which does not exist -> `designer doctor`
+//     never ran for ~2 months and reported exitCode -1 forever (#130).
+//   * auto-heal ran daily with conclusion "success" while unable to patch a
+//     single anchor, because centralizing selectors into selectors.json removed
+//     the inline string literals its AST patcher rewrites (#129 item 0).
+// The through-line: "never ran" was indistinguishable from "healthy". These
+// tests make each layer assert its own capability.
+
+// --- #130: the doctor spawn path ---
+
+test('resolveDoctorBin points at a file that actually exists', () => {
+  const bin = resolveDoctorBin();
+  assert.ok(fs.existsSync(bin), `resolved doctor bin does not exist: ${bin}`);
+});
+
+test('resolveDoctorBin is executable (spawnSync would otherwise EACCES)', () => {
+  const bin = resolveDoctorBin();
+  assert.doesNotThrow(() => fs.accessSync(bin, fs.constants.X_OK), `doctor bin is not executable: ${bin}`);
+});
+
+test('resolveDoctorBin tracks package.json bin, not a guessed filename', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8'));
+  const declared = typeof pkg.bin === 'string' ? pkg.bin : pkg.bin.designer;
+  assert.equal(resolveDoctorBin(), path.join(REPO_ROOT, declared));
+  // The exact bug: the old code joined 'bin', 'designer' and that path is absent.
+  assert.ok(!fs.existsSync(path.join(REPO_ROOT, 'bin', 'designer')), 'bin/designer exists — update this regression test');
+});
+
+test('importing ci-health does not run the probe (module must be side-effect free)', () => {
+  // If the import at the top of this file had launched Chrome and driven
+  // claude.ai, the suite would hang or mutate today's artifact. Reaching this
+  // assertion at all is the check.
+  assert.equal(typeof resolveDoctorBin, 'function');
+});
+
+// --- #129 item 0: auto-heal must know what it can and cannot patch ---
+
+const ALWAYS = () => true;
+const NEVER = () => false;
+
+test('a candidate that cannot be patched is classified apart from one in cooldown', () => {
+  // The 9-day bug in one assertion: the old triage logged both as "complex or
+  // in cooldown" and skipped. One resolves itself; the other never will.
+  const c = classifyCandidates(['stuck', 'waiting'], {
+    canPatch: (id) => id !== 'stuck',
+    inCooldown: (id) => id === 'waiting',
+    isValidId: ALWAYS
+  });
+  assert.deepEqual(c.unpatchable, ['stuck']);
+  assert.deepEqual(c.cooling, ['waiting']);
+  assert.deepEqual(c.eligible, []);
+});
+
+test('isStructurallyBlind fires when work is queued and nothing is patchable', () => {
+  const blind = classifyCandidates(['a', 'b'], { canPatch: NEVER, inCooldown: NEVER, isValidId: ALWAYS });
+  assert.equal(isStructurallyBlind(blind), true, 'unpatchable backlog must be loud');
+});
+
+test('isStructurallyBlind does NOT fire for a pure cooldown wait', () => {
+  // Cooldown is a healthy, self-resolving state — escalating it would train
+  // everyone to ignore the alarm, which is how we got here.
+  const cooling = classifyCandidates(['a'], { canPatch: ALWAYS, inCooldown: ALWAYS, isValidId: ALWAYS });
+  assert.equal(isStructurallyBlind(cooling), false);
+});
+
+test('isStructurallyBlind does NOT fire when something is still healable', () => {
+  const mixed = classifyCandidates(['ok', 'stuck'], {
+    canPatch: (id) => id === 'ok',
+    inCooldown: NEVER,
+    isValidId: ALWAYS
+  });
+  assert.deepEqual(mixed.eligible, ['ok']);
+  assert.equal(isStructurallyBlind(mixed), false);
+});
+
+test('an id failing shape validation is quarantined, never healed', () => {
+  const c = classifyCandidates(['evil; rm -rf /'], { canPatch: ALWAYS, inCooldown: NEVER, isValidId: NEVER });
+  assert.deepEqual(c.invalid, ['evil; rm -rf /']);
+  assert.deepEqual(c.eligible, []);
+});
+
+test('patchableAnchorIds reports reality — today the real anchors are all unpatchable', () => {
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'ui-anchors.ts'), 'utf8');
+  const ids = UI_ANCHORS.map((a) => a.id);
+  const patchable = patchableAnchorIds(src, ids);
+  // Every reported id must genuinely resolve — no claiming coverage it lacks.
+  for (const id of patchable) {
+    assert.ok(findAnchor(src, id), `${id} reported patchable but findAnchor returned null`);
+  }
+  // Documents the standing limitation this PR makes visible rather than hides:
+  // anchors read selectors from selectors.json (SEL.*), which the literal-only
+  // patcher cannot rewrite. If someone extends the patcher, this flips and the
+  // assertion below should be updated deliberately, not by accident.
+  assert.equal(
+    patchable.length,
+    0,
+    `patcher now covers ${patchable.join(', ')} — auto-heal is no longer fully blind; update this test and #129 item 0.`
+  );
+});
+
+test('findAnchor rejects a selector-key anchor rather than silently mispatching', () => {
+  // `hasSelector(b, SEL.home.creator)` is a PropertyAccessExpression, not a
+  // string literal. The patcher must return null (not guess), so auto-heal can
+  // report blindness instead of pretending success.
+  const src = `
+    export const UI_ANCHORS = [
+      { id: 'x.viaSelectorKey', category: 'home', description: 'd', requires: 'home',
+        check: async (b) => ({ ok: await hasSelector(b, SEL.home.creator) }) },
+      { id: 'x.viaLiteral', category: 'home', description: 'd', requires: 'home',
+        check: async (b) => ({ ok: await hasSelector(b, '[data-testid="literal"]') }) }
+    ];`;
+  assert.equal(findAnchor(src, 'x.viaSelectorKey'), null, 'selector-key anchor must not be reported patchable');
+  assert.equal(findAnchor(src, 'x.viaLiteral')?.currentSelector, '[data-testid="literal"]');
+});
+
+// --- #129 items 1+2: legacy branches must degrade, not mask ---
+
+const anchor = (id) => {
+  const a = UI_ANCHORS.find((x) => x.id === id);
+  if (!a) throw new Error(`anchor not found: ${id}`);
+  return a;
+};
+// The stub decides from the evaluated expression, so "which selector is present"
+// is expressed as a predicate over the probe source.
+const stubBrowser = (present) => ({ evalValue: async (expr) => present.some((s) => expr.includes(s)) });
+
+test('canonical selector present => plain ok', async () => {
+  const b = stubBrowser(['home-composer-send']);
+  const r = await anchor('home.createButton').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, true);
+  assert.equal(r.status, undefined, 'canonical match must not be marked degraded');
+});
+
+test('canonical GONE but legacy present => degraded, not ok', async () => {
+  // This is the whole point: the old comma-OR selector reported a clean `ok`
+  // here, so the canonical selector could rot indefinitely without a signal.
+  const b = stubBrowser(['Create']);
+  const r = await anchor('home.createButton').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, true, 'tool still works, so this must not fail the run');
+  assert.equal(r.status, 'degraded');
+  assert.match(r.detail, /canonical/i);
+});
+
+test('neither branch present => fail', async () => {
+  const b = stubBrowser([]);
+  const r = await anchor('home.createButton').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, false);
+});
+
+test('projectsList degrades onto the bare project-link branch', async () => {
+  const b = stubBrowser(['design/p/']);
+  const r = await anchor('home.projectsList').check(b, 'https://claude.ai/design');
+  assert.equal(r.status, 'degraded', 'a stray project link must not read as a healthy list container');
+});
+
+test('login.signedIn degrades on the weaker Create-button marker instead of claiming signed-out', async () => {
+  const b = stubBrowser(['Create']);
+  const r = await anchor('login.signedIn').check(b, 'https://claude.ai/design');
+  assert.equal(r.ok, true);
+  assert.equal(r.status, 'degraded');
+  assert.doesNotMatch(r.detail, /designer setup/, 'must never send the user to re-login on a marker rot');
+});
+
+// --- branch resolution helpers ---
+
+test('orderedBranches keeps canonical first and drops a duplicate legacy', () => {
+  assert.deepEqual(orderedBranches('#a', '#b'), ['#a', '#b']);
+  assert.deepEqual(orderedBranches('#a', '#a'), ['#a'], 'identical legacy is not a second branch');
+  assert.deepEqual(orderedBranches('#a', null), ['#a']);
+});
+
+test('presenceSelector joins branches for existence-only checks', () => {
+  assert.equal(presenceSelector('#a', '#b'), '#a, #b');
+  assert.equal(presenceSelector('#a', null), '#a');
+});
+
+test('no canonical selector smuggles a comma-OR legacy branch back in', () => {
+  // Guards the regression directly: if someone re-packs a fallback into a
+  // canonical selector, querySelector's document-order semantics silently
+  // return again and the anchors stop degrading.
+  const sel = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'selectors.json'), 'utf8'));
+  for (const [key, value] of Object.entries(sel.home)) {
+    assert.ok(!String(value).includes(','), `home.${key} packs multiple branches into one selector: ${value}`);
+  }
+});

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -367,3 +367,38 @@ test('CDP-unreachable is incomplete, never drift', () => {
   const cdpBlock = src.slice(at, at + 600);
   assert.match(cdpBlock, /exitWith\('incomplete'\)/, 'CDP-unreachable must resolve to incomplete');
 });
+
+test('the auto-heal workflow fails the job when triage reports structural blindness', () => {
+  // ::error is an annotation; it does not change a step's outcome. Without an
+  // explicit gate the workflow still concluded success in exactly the
+  // blind-while-anchors-fail scenario this PR exists to surface.
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/auto-heal.yml'), 'utf8');
+  assert.ok(
+    wf.includes("steps.triage.outputs.reason == 'blind-unpatchable'"),
+    'no workflow gate on the blind-unpatchable reason — auto-heal would stay green while blind'
+  );
+  const gateIdx = wf.indexOf("steps.triage.outputs.reason == 'blind-unpatchable'");
+  assert.match(wf.slice(gateIdx, gateIdx + 500), /exit 1/, 'the blind gate must actually fail the job');
+});
+
+test('the blind reason string is emitted by triage exactly as the workflow expects', () => {
+  // Guards the two halves drifting apart: a renamed reason would silently make
+  // the gate dead, restoring the green-while-blind behaviour.
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/auto-heal.ts'), 'utf8');
+  assert.match(src, /ghOutput\('reason', 'blind-unpatchable'\)/, 'triage no longer emits the reason the workflow gates on');
+});
+
+test('no health-apparatus script keeps its own hardcoded readiness selector', () => {
+  // There were two stale copies of these gates — ci-health.ts and auto-heal.ts —
+  // and the home one pointed at `project-creator`, dead since a redesign. Both
+  // burned the full timeout waiting for an element that could never appear and
+  // then proceeded with no readiness guarantee.
+  for (const f of ['scripts/ci-health.ts', 'scripts/auto-heal.ts']) {
+    const src = fs.readFileSync(path.join(REPO_ROOT, f), 'utf8');
+    const decls = src.match(/^const (?:HOME|SESSION)_READY_SEL = .*$/gm) || [];
+    assert.ok(decls.length > 0, `${f}: readiness selectors not found — update this test`);
+    for (const d of decls) {
+      assert.ok(/= SEL\./.test(d), `${f} hardcodes a readiness selector instead of reading selectors.json: ${d}`);
+    }
+  }
+});

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { resolveDoctorBin } from '../scripts/ci-health.ts';
+import { resolveDoctorBin, probeVerdict, EXIT_CODE } from '../scripts/ci-health.ts';
 import { findAnchor, canPatch } from '../scripts/anchor-patcher.ts';
 import { classifyCandidates, isStructurallyBlind, patchableAnchorIds } from '../scripts/auto-heal.ts';
 import { orderedBranches, presenceSelector } from '../selectors.ts';
@@ -253,4 +253,54 @@ test('every ProbeStatus is rendered distinctly by the CLI health reporter', () =
   const icons = cli.match(/const icon = \(s: string\) => \(([^;]+)\);/);
   assert.ok(icons, 'icon renderer not found — update this test');
   assert.match(icons[1], /'degraded'/, "degraded has no glyph of its own");
+});
+
+// --- PR #131 review round 3: the probe needs a third outcome ---
+
+test('a clean run with a working doctor is ok', () => {
+  assert.equal(probeVerdict({ anchorFail: false, doctorSpawnError: null, doctorExitCode: 0 }), 'ok');
+});
+
+test('anchor regressions are drift — the selectors-drift-PR path', () => {
+  assert.equal(probeVerdict({ anchorFail: true, doctorSpawnError: null, doctorExitCode: 0 }), 'drift');
+});
+
+test('a doctor that never launched is incomplete, NOT green and NOT drift', () => {
+  // The bug this closes: exit 0 made `Close stale drift PRs on green` fire while
+  // half the probe was broken, so a legitimate open drift PR could be
+  // auto-closed. Exit 2 would have been just as wrong — it would file a tooling
+  // fault as a claude.ai redesign.
+  const v = probeVerdict({ anchorFail: false, doctorSpawnError: 'ENOENT: ...', doctorExitCode: -1 });
+  assert.equal(v, 'incomplete');
+  assert.notEqual(v, 'ok');
+  assert.notEqual(v, 'drift');
+});
+
+test('a doctor that ran but reported a broken toolchain is incomplete', () => {
+  assert.equal(probeVerdict({ anchorFail: false, doctorSpawnError: null, doctorExitCode: 2 }), 'incomplete');
+});
+
+test('anchor drift outranks a broken doctor — the actionable signal wins', () => {
+  // Both broken: still file the drift PR. Drift is what a human can act on, and
+  // the doctor fault is recorded in the artifact either way.
+  assert.equal(probeVerdict({ anchorFail: true, doctorSpawnError: 'ENOENT: ...', doctorExitCode: -1 }), 'drift');
+});
+
+test('each verdict maps to a distinct exit code, and only ok is zero', () => {
+  assert.equal(EXIT_CODE.ok, 0);
+  assert.notEqual(EXIT_CODE.drift, 0);
+  assert.notEqual(EXIT_CODE.incomplete, 0);
+  assert.notEqual(EXIT_CODE.drift, EXIT_CODE.incomplete, 'drift and incomplete must be distinguishable');
+  assert.equal(new Set(Object.values(EXIT_CODE)).size, 3);
+});
+
+test('the workflow gates on the verdict, never on the raw step outcome', () => {
+  // `outcome` is only success/failure, so it cannot separate drift from a broken
+  // probe — and the probe step runs with continue-on-error, so a bare outcome
+  // check let an incomplete run pass as green.
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/daily-health.yml'), 'utf8');
+  assert.doesNotMatch(wf, /steps\.probe\.outcome/, 'a gate still keys on step outcome instead of the verdict');
+  for (const v of ['ok', 'drift', 'incomplete']) {
+    assert.ok(wf.includes(`steps.probe.outputs.verdict == '${v}'`), `no workflow step handles verdict '${v}'`);
+  }
 });

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -172,7 +172,12 @@ test('login.signedIn degrades on the weaker Create-button marker instead of clai
   const r = await anchor('login.signedIn').check(b, 'https://claude.ai/design');
   assert.equal(r.ok, true);
   assert.equal(r.status, 'degraded');
-  assert.doesNotMatch(r.detail, /designer setup/, 'must never send the user to re-login on a marker rot');
+  // NOT a hard ban on naming `designer setup` here: this branch concedes the
+  // marker is weak evidence, so forbidding the words forced the text to assert
+  // more certainty than the check has. What must hold is that re-capture is
+  // named FIRST and setup only as a conditional secondary.
+  assert.match(r.detail, /re-capture login\.signedInIndicator/i, 'must lead with re-capture, not re-login');
+  assert.match(r.detail, /WEAK evidence/, 'must state the marker is weak evidence rather than assert authentication');
 });
 
 // --- branch resolution helpers ---
@@ -606,4 +611,17 @@ test('the direct-invocation guard compares realpaths on both sides', () => {
     assert.match(src, /realpathSync\(fileURLToPath\(import\.meta\.url\)\)/, `${f}: import side not realpath'd`);
     assert.match(src, /fs\.realpathSync\(process\.argv\[1\]\)/, `${f}: argv side not realpath'd`);
   }
+});
+
+test('idOf admits a trailing slash but still rejects project subroutes', () => {
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'designer-controller.ts'), 'utf8');
+  const m = src.match(/pathname\.match\(\/(.+?)\/i\)/);
+  assert.ok(m, 'idOf regex not found — update this test');
+  // The pattern lives inside a TS template literal, so a source `\\\\/` reaches
+  // the page as `\/`. Collapse it back so the real boundary is exercised.
+  const re = new RegExp(m[1].replace(/\\\\\//g, '/'), 'i');
+  const uuid = '11111111-1111-1111-1111-111111111111';
+  assert.ok(re.test(`/design/p/${uuid}`), 'bare project path must match');
+  assert.ok(re.test(`/design/p/${uuid}/`), 'trailing slash must match (#F8)');
+  assert.ok(!re.test(`/design/p/${uuid}/settings`), 'subroutes must NOT match — they become phantom projects');
 });

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -299,8 +299,71 @@ test('the workflow gates on the verdict, never on the raw step outcome', () => {
   // probe — and the probe step runs with continue-on-error, so a bare outcome
   // check let an incomplete run pass as green.
   const wf = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/daily-health.yml'), 'utf8');
-  assert.doesNotMatch(wf, /steps\.probe\.outcome/, 'a gate still keys on step outcome instead of the verdict');
   for (const v of ['ok', 'drift', 'incomplete']) {
     assert.ok(wf.includes(`steps.probe.outputs.verdict == '${v}'`), `no workflow step handles verdict '${v}'`);
   }
+  // Scoped to `if:` CONDITIONS, not the whole file — naming `outcome` inside a
+  // diagnostic message is fine; gating on it is what cannot happen, because
+  // outcome collapses drift and a broken probe into one `failure`.
+  const lines = wf.split('\n');
+  const conditions = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(\s*)if:(.*)$/);
+    if (!m) continue;
+    let cond = m[2];
+    const indent = m[1].length;
+    for (let j = i + 1; j < lines.length; j++) {
+      const next = lines[j];
+      if (!next.trim()) break;
+      const nextIndent = next.length - next.trimStart().length;
+      if (nextIndent <= indent) break;
+      cond += ' ' + next.trim();
+    }
+    conditions.push(cond);
+  }
+  assert.ok(conditions.length >= 3, 'expected at least the three verdict gates');
+  for (const c of conditions) {
+    assert.ok(!c.includes('steps.probe.outcome'), `a gate still keys on step outcome: ${c.trim().slice(0, 80)}`);
+  }
+});
+
+// --- PR #131 review round 4: no exit path may skip the verdict ---
+
+test('every process exit in ci-health goes through exitWith', () => {
+  // The regression this closes: the CDP-unreachable path and the main().catch
+  // handler exited without publishing a verdict. With `continue-on-error: true`
+  // on the probe step, an unset verdict left all gates false and the job GREEN —
+  // strictly worse than before, when a bare non-zero exit at least went red.
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/ci-health.ts'), 'utf8');
+  const bare = src
+    .split('\n')
+    .map((line, i) => ({ line: line.trim(), n: i + 1 }))
+    .filter(({ line }) => line.includes('process.exit('))
+    // The single legitimate call is the one inside exitWith itself.
+    .filter(({ n }) => {
+      const fnStart = src.slice(0, src.indexOf('function exitWith')).split('\n').length;
+      return !(n >= fnStart && n <= fnStart + 8);
+    });
+  assert.deepEqual(bare, [], `these exits bypass exitWith and would publish no verdict: ${JSON.stringify(bare)}`);
+});
+
+test('the workflow fails closed on an unrecognized or missing verdict', () => {
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/daily-health.yml'), 'utf8');
+  // A hard kill (OOM / runner timeout) writes no output at all, so the guard
+  // cannot live in the script — the workflow must reject anything unknown.
+  for (const v of ['ok', 'drift', 'incomplete']) {
+    assert.ok(wf.includes(`steps.probe.outputs.verdict != '${v}'`), `backstop does not exclude the known verdict '${v}'`);
+  }
+});
+
+test('CDP-unreachable is incomplete, never drift', () => {
+  // A dead browser is an environment fault. It used to exit 2, which opened a
+  // selectors-drift PR blaming claude.ai for a Chrome that would not start.
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/ci-health.ts'), 'utf8');
+  // Anchored on the FAIL log specifically — an earlier line logs the benign
+  // "attempting relaunch" case with nearly the same wording.
+  const at = src.indexOf('FAIL — CDP unreachable on');
+  assert.notEqual(at, -1, 'CDP-unreachable failure log not found — update this test');
+  const cdpBlock = src.slice(at, at + 600);
+  assert.match(cdpBlock, /exitWith\('incomplete'\)/, 'CDP-unreachable must resolve to incomplete');
 });

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -554,3 +554,34 @@ test('every selector is either anchored in ui-anchors.ts or explicitly exempt', 
   }
   assert.deepEqual(unanchored, [], `selectors with no health anchor and no documented exemption: ${unanchored.join(', ')}`);
 });
+
+// --- Theme B: ProbeStatus consumers must be total over the union ---
+
+test('isFailing / isWorking classify every ProbeStatus, and degraded is working', async () => {
+  const { isFailing, isWorking } = await import('../ui-anchors.ts');
+  assert.equal(isFailing('fail'), true);
+  for (const s of ['ok', 'degraded', 'skip']) assert.equal(isFailing(s), false, `${s} must not read as failing`);
+  // The F10 defect: degraded means the anchor WORKS via a superseded branch, so
+  // a re-probe returning it must not revert a patch that succeeded.
+  assert.equal(isWorking('degraded'), true);
+  assert.equal(isWorking('ok'), true);
+  assert.equal(isWorking('fail'), false);
+  assert.equal(isWorking('skip'), false);
+});
+
+test('auto-heal judges its re-probe with the shared predicate, not a literal !== ok', () => {
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/auto-heal.ts'), 'utf8');
+  assert.ok(!/status !== 'ok'/.test(src), "auto-heal still uses `status !== 'ok'` — degraded would revert a working patch");
+  assert.match(src, /isFailing\(r\.status\)/, 'auto-heal must consume the shared predicate');
+});
+
+test('a degraded run does not close the drift PR that documents the rot', () => {
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/daily-health.yml'), 'utf8');
+  const gate = wf.slice(wf.indexOf('Close stale drift PRs on green'));
+  assert.match(gate, /steps\.probe\.outputs\.degraded == '0'/, 'stale-close must be withheld while anchors are degraded');
+});
+
+test('the degraded count is published for the workflow to gate on', () => {
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/ci-health.ts'), 'utf8');
+  assert.match(src, /ghOutput\('degraded', String\(counts\.degraded\)\)/);
+});

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -373,12 +373,9 @@ test('the auto-heal workflow fails the job when triage reports structural blindn
   // explicit gate the workflow still concluded success in exactly the
   // blind-while-anchors-fail scenario this PR exists to surface.
   const wf = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/auto-heal.yml'), 'utf8');
-  assert.ok(
-    wf.includes("steps.triage.outputs.reason == 'blind-unpatchable'"),
-    'no workflow gate on the blind-unpatchable reason — auto-heal would stay green while blind'
-  );
-  const gateIdx = wf.indexOf("steps.triage.outputs.reason == 'blind-unpatchable'");
-  assert.match(wf.slice(gateIdx, gateIdx + 500), /exit 1/, 'the blind gate must actually fail the job');
+  const GATE = "steps.triage.outputs.blind == 'true'";
+  assert.ok(wf.includes(GATE), 'no workflow gate on blindness — auto-heal would stay green while blind');
+  assert.match(wf.slice(wf.indexOf(GATE), wf.indexOf(GATE) + 500), /exit 1/, 'the blind gate must actually fail the job');
 });
 
 test('the blind reason string is emitted by triage exactly as the workflow expects', () => {
@@ -401,4 +398,50 @@ test('no health-apparatus script keeps its own hardcoded readiness selector', ()
       assert.ok(/= SEL\./.test(d), `${f} hardcodes a readiness selector instead of reading selectors.json: ${d}`);
     }
   }
+});
+
+// --- PR #131 review round 6 ---
+
+test('blindness is classified before the wholesale-redesign early return', () => {
+  // The gap: >=5 failing anchors returned reason=wholesale-redesign BEFORE the
+  // classification ran, so a wholesale regression in which nothing was
+  // patchable never reported blindness — the worst case (many anchors down,
+  // auto-heal powerless) stayed green.
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/auto-heal.ts'), 'utf8');
+  const classifyAt = src.indexOf('const classified = classifyCandidates(');
+  const wholesaleAt = src.indexOf('candidates.length >= WHOLESALE_THRESHOLD');
+  assert.notEqual(classifyAt, -1);
+  assert.notEqual(wholesaleAt, -1);
+  assert.ok(classifyAt < wholesaleAt, 'classification must run before the wholesale early return');
+});
+
+test('every triage exit publishes a blind flag', () => {
+  // Same lesson as the ci-health verdict: a gate keyed on an output only works
+  // if every exit sets it, or the unset case silently gates to green.
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/auto-heal.ts'), 'utf8');
+  const start = src.indexOf('function triage()');
+  const end = src.indexOf('// ---- heal ----');
+  assert.ok(start > 0 && end > start, 'triage() bounds not found — update this test');
+  const triage = src.slice(start, end);
+  const reasons = (triage.match(/ghOutput\('reason',/g) || []).length;
+  const blinds = (triage.match(/ghOutput\('blind',/g) || []).length;
+  const heals = (triage.match(/ghOutput\('action', 'heal'\)/g) || []).length;
+  assert.ok(reasons > 0, 'no triage reasons found — update this test');
+  assert.equal(blinds, reasons + heals, `every exit must publish blind: ${reasons} reasons + ${heals} heal vs ${blinds} blind flags`);
+});
+
+test('the auto-heal gate keys on blind, not on a single reason slot', () => {
+  const wf = fs.readFileSync(path.join(REPO_ROOT, '.github/workflows/auto-heal.yml'), 'utf8');
+  assert.ok(wf.includes("steps.triage.outputs.blind == 'true'"), 'gate must key on the dedicated blind output');
+  // reason can only hold one value, so wholesale-redesign would mask blindness.
+  assert.ok(!wf.includes("reason == 'blind-unpatchable'"), 'gate still keys on the mutually-exclusive reason slot');
+});
+
+test('project names are chosen by source priority, not string length', () => {
+  // A control link ("Open") is SHORTER than the real name, so shortest-wins
+  // picked the button label on exactly the multi-link row the dedupe exists for.
+  const src = fs.readFileSync(path.join(REPO_ROOT, 'designer-controller.ts'), 'utf8');
+  const scrape = src.slice(src.indexOf('const LINK_SEL ='), src.indexOf('async listFiles('));
+  assert.ok(!/sort\(\(x, y\) => x\.length - y\.length\)/.test(scrape), 'shortest-wins heuristic is back');
+  assert.match(scrape, /NAME_SOURCES = \['rowCell', 'ariaLabel', 'anchorText'\]/, 'source priority order changed');
 });

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -585,3 +585,25 @@ test('the degraded count is published for the workflow to gate on', () => {
   const src = fs.readFileSync(path.join(REPO_ROOT, 'scripts/ci-health.ts'), 'utf8');
   assert.match(src, /ghOutput\('degraded', String\(counts\.degraded\)\)/);
 });
+
+test('the scrubber redacts a home dir whose username contains spaces', async () => {
+  // /Users/<first> <last>/ leaked the surname: [^/\s] stops at the space, so
+  // only the first token was redacted.
+  const { scrubForTest } = await import('../scripts/ci-health.ts');
+  assert.equal(scrubForTest('/Users/Provi Last/x/bin/designer'), '/Users/<redacted>/x/bin/designer');
+  assert.equal(scrubForTest('/home/runner work/y/z'), '/home/<redacted>/y/z');
+  // Still handles the trailing-segment form, and does not run away over prose.
+  assert.equal(scrubForTest('spawnSync /Users/provi ENOENT'), 'spawnSync /Users/<redacted> ENOENT');
+  assert.equal(scrubForTest('no path here at all'), 'no path here at all');
+});
+
+test('the direct-invocation guard compares realpaths on both sides', () => {
+  // import.meta.url is already symlink-resolved; comparing it to a raw argv[1]
+  // makes the guard silently false under a symlinked checkout, so the script
+  // would be imported but never run.
+  for (const f of ['scripts/ci-health.ts', 'scripts/auto-heal.ts']) {
+    const src = fs.readFileSync(path.join(REPO_ROOT, f), 'utf8');
+    assert.match(src, /realpathSync\(fileURLToPath\(import\.meta\.url\)\)/, `${f}: import side not realpath'd`);
+    assert.match(src, /fs\.realpathSync\(process\.argv\[1\]\)/, `${f}: argv side not realpath'd`);
+  }
+});

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -197,3 +197,39 @@ test('no canonical selector smuggles a comma-OR legacy branch back in', () => {
     assert.ok(!String(value).includes(','), `home.${key} packs multiple branches into one selector: ${value}`);
   }
 });
+
+// --- PR #131 review (Codex P2 x2) ---
+
+test('doctor spawnError is scrubbed of the runner home path before it is published', async () => {
+  // Node embeds the absolute executable path in spawn errors. The health
+  // artifact is a world-downloadable public-repo artifact for 30 days, and the
+  // same string also reaches the run summary + a ::warning annotation, so the
+  // scrub has to happen at the source, not at payload-assembly time.
+  const { spawnSync } = await import('node:child_process');
+  const r = spawnSync(path.join(REPO_ROOT, 'bin', 'designer'), ['doctor']);
+  assert.ok(r.error, 'expected ENOENT for the extensionless path');
+  assert.match(r.error.message, /\/Users\/|\/home\//, 'precondition: raw message carries a home path');
+
+  const { scrubForTest } = await import('../scripts/ci-health.ts');
+  const scrubbed = scrubForTest(`${r.error.code}: ${r.error.message}`);
+  assert.doesNotMatch(scrubbed, /\/Users\/(?!<redacted>)[^/\s]+/, 'macOS username leaked');
+  assert.doesNotMatch(scrubbed, /\/home\/(?!<redacted>)[^/\s]+/, 'Linux username leaked');
+  assert.match(scrubbed, /ENOENT/, 'scrubbing must preserve the diagnostic');
+});
+
+test('every ProbeStatus is rendered distinctly by the CLI health reporter', () => {
+  // Guards the enum-widening gap: `degraded` was added to ProbeStatus but the
+  // `designer health` reporter still hardcoded ok/fail/skip, so counts did not
+  // add up to results.length and degraded shared an icon with skip.
+  const cli = fs.readFileSync(path.join(REPO_ROOT, 'cli.ts'), 'utf8');
+  for (const status of ['ok', 'degraded', 'fail', 'skip']) {
+    assert.ok(
+      cli.includes(`counts['${status}']`),
+      `cli.ts health output does not account for the '${status}' status — totals will not add up`
+    );
+  }
+  // Distinct glyphs: degraded must not collapse into the skip fallback.
+  const icons = cli.match(/const icon = \(s: string\) => \(([^;]+)\);/);
+  assert.ok(icons, 'icon renderer not found — update this test');
+  assert.match(icons[1], /'degraded'/, "degraded has no glyph of its own");
+});

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -292,7 +292,7 @@ export const UI_ANCHORS: AnchorDef[] = [
           return {
             ok: true,
             status: 'degraded',
-            detail: `signed-in marker matched only the superseded branch (${legacyMarker}); canonical composer testids absent. Re-capture login.signedInIndicator — do NOT re-login.`
+            detail: `signed-in marker matched only the superseded branch (${legacyMarker}); canonical composer testids absent. This branch is WEAK evidence of authentication (an action button could plausibly render on an unauthenticated shell), so treat sign-in as unconfirmed: re-capture login.signedInIndicator first, and only if the composer is genuinely absent while signed in does \`designer setup\` apply.`
           };
         }
         // The signed-in marker is absent. Before reporting "signed out" (which

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -24,6 +24,39 @@ export type AnchorState = 'home' | 'session' | 'any';
 // this existed the legacy branch was packed into the same comma-OR selector and
 // simply kept the anchor green, hiding the canonical rot from the daily probe.
 export type ProbeStatus = 'ok' | 'degraded' | 'fail' | 'skip';
+
+/**
+ * Typed predicates over ProbeStatus, exported so every consumer classifies the
+ * same way. Written as exhaustive switches: adding a status value makes these a
+ * COMPILE error instead of a silent misclassification somewhere downstream.
+ *
+ * Widening the union to include `degraded` without making its consumers total is
+ * how two separate decision points went wrong — a verdict that ignored it, and a
+ * re-probe that reverted a working patch because the anchor was not literally
+ * 'ok'.
+ */
+export function isFailing(s: ProbeStatus): boolean {
+  switch (s) {
+    case 'fail':
+      return true;
+    case 'ok':
+    case 'degraded':
+    case 'skip':
+      return false;
+  }
+}
+
+/** True when the anchor is working — including via a superseded selector. */
+export function isWorking(s: ProbeStatus): boolean {
+  switch (s) {
+    case 'ok':
+    case 'degraded':
+      return true;
+    case 'fail':
+    case 'skip':
+      return false;
+  }
+}
 export type ProbePhase = 'home' | 'session';
 
 export interface ProbeResult {

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -18,7 +18,12 @@ const SEL = getSelectors();
 
 export type AnchorCategory = 'home' | 'session' | 'share' | 'pattern';
 export type AnchorState = 'home' | 'session' | 'any';
-export type ProbeStatus = 'ok' | 'fail' | 'skip';
+// `degraded` = the canonical selector is GONE but a superseded legacy branch
+// still matches. The tool keeps working, so this is not a `fail` (it must not
+// open drift PRs or go red), but it is emphatically not `ok` either — before
+// this existed the legacy branch was packed into the same comma-OR selector and
+// simply kept the anchor green, hiding the canonical rot from the daily probe.
+export type ProbeStatus = 'ok' | 'degraded' | 'fail' | 'skip';
 export type ProbePhase = 'home' | 'session';
 
 export interface ProbeResult {
@@ -47,6 +52,32 @@ async function hasSelector(browser: Browser, sel: string): Promise<boolean> {
   return !!(await browser
     .evalValue<boolean>(`!!document.querySelector(${JSON.stringify(sel)})`)
     .catch(() => false));
+}
+
+/**
+ * Probe a canonical selector, falling back to a superseded one ONLY to
+ * distinguish "still works via the old shape" from "gone entirely".
+ *
+ * Ordered on purpose: packing both into one `querySelector('A, B')` would return
+ * whichever comes first in document order — not the canonical match — and would
+ * report plain `ok` either way, which is exactly how legacy branches masked
+ * canonical rot from the daily probe.
+ */
+async function checkWithLegacy(
+  browser: Browser,
+  canonical: string,
+  legacy: string | null | undefined,
+  label: string
+): Promise<{ ok: boolean; status?: ProbeStatus; detail?: string }> {
+  if (await hasSelector(browser, canonical)) return { ok: true };
+  if (legacy && (await hasSelector(browser, legacy))) {
+    return {
+      ok: true,
+      status: 'degraded',
+      detail: `canonical ${label} selector (${canonical}) is GONE; still matching the superseded branch (${legacy}). Re-capture the canonical selector — the tool works today but this is unrepaired drift.`
+    };
+  }
+  return { ok: false, detail: `neither canonical (${canonical}) nor legacy (${legacy ?? 'none'}) matched` };
 }
 
 // True on a `.dc.html` DESIGN-CANVAS session (a Figma-like editor — dc-tool-*,
@@ -217,8 +248,20 @@ export const UI_ANCHORS: AnchorDef[] = [
       // this signed-in check (the #16/#32 false-positive this anchor guards). Its
       // absence means the login wall is served at the /design URL — fail loudly.
       if (/claude\.ai\/design/.test(url)) {
-        const signedIn = await hasSelector(b, SEL.login.signedInIndicator ?? '');
-        if (signedIn) return { ok: true };
+        if (await hasSelector(b, SEL.login.signedInIndicator ?? '')) return { ok: true };
+        // Legacy arm: `button[title="Create"]` used to be packed into the same
+        // comma-OR as the composer testids. It is weaker evidence of auth than a
+        // composer (an action button could plausibly render on an unauthenticated
+        // shell), so it no longer counts as a clean pass — but it still beats
+        // sending the user to re-login. Keep it, mark it degraded.
+        const legacyMarker = SEL.loginLegacy?.signedInIndicator;
+        if (legacyMarker && (await hasSelector(b, legacyMarker))) {
+          return {
+            ok: true,
+            status: 'degraded',
+            detail: `signed-in marker matched only the superseded branch (${legacyMarker}); canonical composer testids absent. Re-capture login.signedInIndicator — do NOT re-login.`
+          };
+        }
         // The signed-in marker is absent. Before reporting "signed out" (which
         // sends the user to re-login), check for an unambiguous signed-in-home
         // landmark the login wall never renders — a project link or the home
@@ -288,23 +331,23 @@ export const UI_ANCHORS: AnchorDef[] = [
   {
     id: 'home.createButton',
     category: 'home',
-    description: 'creation submit button ([data-testid="home-composer-send"] / button[title="Create"])',
+    description: 'creation submit button ([data-testid="home-composer-send"])',
     requires: 'home',
-    check: async (b) => ({ ok: await hasSelector(b, SEL.home.createButton) })
+    check: async (b) => checkWithLegacy(b, SEL.home.createButton, SEL.homeLegacy?.createButton, 'home.createButton')
   },
   {
     id: 'home.projectsList',
     category: 'home',
     description: 'project list ([data-testid="projects-list"])',
     requires: 'home',
-    check: async (b) => ({ ok: await hasSelector(b, SEL.home.projectsList) })
+    check: async (b) => checkWithLegacy(b, SEL.home.projectsList, SEL.homeLegacy?.projectsList, 'home.projectsList')
   },
   {
     id: 'home.projectCard',
     category: 'home',
     description: 'project row ([data-testid="project-row"])',
     requires: 'home',
-    check: async (b) => ({ ok: await hasSelector(b, SEL.home.projectCard) })
+    check: async (b) => checkWithLegacy(b, SEL.home.projectCard, SEL.homeLegacy?.projectCard, 'home.projectCard')
   },
 
   // --- inside a session (after /design/p/{uuid}) ---

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -343,6 +343,18 @@ export const UI_ANCHORS: AnchorDef[] = [
     check: async (b) => checkWithLegacy(b, SEL.home.projectsList, SEL.homeLegacy?.projectsList, 'home.projectsList')
   },
   {
+    id: 'home.projectLink',
+    category: 'home',
+    // The selector `listProjects()` actually scrapes. It had NO anchor: the
+    // probe read green off projectsList/projectCard while `designer list` could
+    // return []. `home.projectCard` carries the link only as a LEGACY branch,
+    // which checkWithLegacy never evaluates while the canonical row matches — so
+    // it could not stand in for this.
+    description: 'per-project link (a[href*="/design/p/"]) — the listProjects scrape target',
+    requires: 'home',
+    check: async (b) => ({ ok: await hasSelector(b, SEL.home.projectLink) })
+  },
+  {
     id: 'home.projectCard',
     category: 'home',
     description: 'project row ([data-testid="project-row"])',
@@ -411,8 +423,11 @@ export const UI_ANCHORS: AnchorDef[] = [
     description: 'send button',
     requires: 'session',
     // The 2026-06 build dropped data-testid="chat-send-button"; the button is
-    // now only identifiable by its title="Send (Enter)". Match either.
-    check: async (b) => ({ ok: await hasSelector(b, SEL.composer.sendButton) })
+    // now only identifiable by its title="Send (Enter)". These were packed into
+    // ONE comma-OR selector, so this anchor reported a clean `ok` while matching
+    // only the superseded branch — the exact masking `degraded` exists to
+    // surface, sitting live in the repo that introduced it.
+    check: async (b) => checkWithLegacy(b, SEL.composer.sendButton, SEL.composerLegacy?.sendButton, 'composer.sendButton')
   },
   {
     id: 'session.htmlViewerIframe',

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -4,7 +4,7 @@ import { isPreviewIframeSrc, previewIframeVariant, isBootstrapShellHtml } from '
 import { isCdpEnabled } from './cdp-env.ts';
 import { OopifHtmlReader } from './oopif-reader.ts';
 import { OPEN_FILES_PANEL_EXPR } from './file-panel.ts';
-import { getSelectors } from './selectors.ts';
+import { getSelectors, orderedBranches } from './selectors.ts';
 
 // Every UI anchor this MCP depends on to work. Grouped by the surface state
 // they live on. A regression in Claude Design's UI will trip one or more of
@@ -153,6 +153,15 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Ordered canonical-then-legacy branches for the composer send button, embedded
+// into the in-page snippets below. Splitting composer.sendButton into
+// canonical + composerLegacy made the canonical selector alone insufficient here:
+// ui-anchors itself records that data-testid="chat-send-button" was dropped in
+// the 2026-06 build, so a raw canonical lookup finds nothing on the live UI.
+// Resolved in order rather than comma-joined, so a stale duplicate earlier in
+// the document cannot win the click.
+const SEND_BRANCHES_JSON = JSON.stringify(orderedBranches(SEL.composer.sendButton, SEL.composerLegacy?.sendButton));
+
 async function submitTurnRpcCanary(browser: Browser): Promise<{ ok: boolean; detail?: string }> {
   const prompt =
     'Health check: answer in chat only with the single word ok. Do not create, modify, or delete files.';
@@ -192,7 +201,8 @@ async function submitTurnRpcCanary(browser: Browser): Promise<{ ok: boolean; det
     const disabled = await browser
       .evalValue<boolean>(
         `(() => {
-          const b = document.querySelector(${JSON.stringify(SEL.composer.sendButton)});
+          let b = null;
+          for (const s of ${SEND_BRANCHES_JSON}) { b = document.querySelector(s); if (b) break; }
           return !b || b.disabled || b.getAttribute('aria-disabled') === 'true';
         })()`
       )
@@ -204,7 +214,8 @@ async function submitTurnRpcCanary(browser: Browser): Promise<{ ok: boolean; det
   const clicked = await browser
     .evalValue<boolean>(
       `(() => {
-        const b = document.querySelector(${JSON.stringify(SEL.composer.sendButton)});
+        let b = null;
+        for (const s of ${SEND_BRANCHES_JSON}) { b = document.querySelector(s); if (b) break; }
         if (!b || b.disabled || b.getAttribute('aria-disabled') === 'true') return false;
         b.click();
         return true;


### PR DESCRIPTION
Closes #130. Addresses #129 items 0–5.

After the nine-day #118–#126 pileup I audited the apparatus that was *supposed* to catch it. Three layers each reported success while asserting nothing. In all three, **"never ran" was indistinguishable from "healthy."**

## 1. `designer doctor` had never run (#130)

`ci-health.ts` spawned `bin/designer`. The file is **`bin/designer.mjs`**. So `spawnSync` failed `ENOENT`, `r.status` was `null`, `?? -1` rendered that as `exitCode: -1`, and `r.error` was thrown away — which is why stdout *and* stderr were both empty.

```
bin/designer       status= null  error= ENOENT  stdoutBytes= 0
bin/designer.mjs   status= 2     error= none    stdoutBytes= 634
```

Every artifact from 2026-05-25 to 2026-07-25 carried the identical `-1`. The probe's own header claims it "combines `designer doctor` (tooling state) + `designer health` (UI)" — **only the UI half ever executed.**

Now: the bin is resolved from `package.json`'s `bin` map (a rename can't silently re-break it), a launch failure is a distinct `spawnError` field instead of being flattened into an exit code, and it emits a workflow warning. It deliberately does **not** flip `payload.ok` — a tooling fault must not start opening drift PRs.

## 2. auto-heal was structurally blind (#129 item 0)

The AST patcher only rewrites `hasSelector(b, '<string literal>')`. Centralizing selectors into `selectors.json` — a *correct* decision — rewrote every anchor to `hasSelector(b, SEL.home.creator)`, a property access. Two individually-right choices, jointly incompatible, with nothing testing the seam. All 24 anchors are `UNPATCHABLE`; `home.creator` sat at streak 9 while auto-heal ran daily with conclusion **success**.

Triage collapsed two opposite states into one line — *"all candidates either complex or in cooldown"*. Cooldown self-resolves; unpatchable never will. `classifyCandidates` now splits them, and `isStructurallyBlind` escalates the permanent case with a `::error`, a `blind-unpatchable` reason, and a one-time comment + `auto-heal-blind` label on the drift PR.

I did **not** extend the patcher to rewrite `selectors.json` values. That's a wider blast radius (LLM-driven mutation of the contract every consumer reads) and wants its own dry-run gate. A test pins the current reality so extending it is a deliberate act, not an accident.

## 3. Legacy branches masked canonical rot (#129 items 1–2)

`querySelector('A, B')` returns the first match in **document order** — not A preferred over B. My own #127 description called these "fallbacks," which was wrong. Packing a legacy branch into a canonical selector can return the wrong element at runtime *and* keeps a presence-only anchor green after the canonical selector is gone.

Canonical selectors are now single-branch; superseded forms live in `homeLegacy` / `loginLegacy`. An anchor matching only the legacy branch reports a new **`degraded`** status — counted and warned on, never `fail`, because the tool still works. Runtime resolves in explicit order (`orderedBranches`); presence-only checks use `presenceSelector`, which is safe precisely because the caller doesn't care which element comes back.

## 4. listProjects extraction (#129 items 3–5)

- `seen.add()` fired **before** the name resolved, so a row whose first anchor was a nameless icon link emitted `name: null` and skipped the anchor that had the name. Candidates are now collected per uuid and chosen after.
- `closest('[project-row], tr')` matches either branch nearest-first, so a nested `<tr>` could win. Tries the specific row first now.
- The uuid is parsed from the URL **pathname**, not an href substring — so `/design/p/<uuid>/settings` and `?to=/design/p/<uuid>` decoys no longer contribute their own text as project names.
- Selectors come from `selectors.json` instead of being inlined.

## Also fixed along the way

- **`HOME_READY_SEL` was a dead hardcoded `[data-testid="project-creator"]`.** Every run burned the full 15s readiness wait for an element that could never appear, then proceeded *without* a readiness guarantee — `adaptiveWait` only logs on timeout. Both ready selectors now come from `selectors.json`.
- **Neither `ci-health` nor `auto-heal` was importable**: both ran `main()` at module load, so nothing in them could be tested without launching Chrome or calling the Anthropic API. (I found this by importing one and watching it drive claude.ai.) Both are guarded now — that's what makes these tests possible at all.
- **Orphan streak keys pruned** (`home.nameInput: 2` outlived its anchor). Keyed on the anchor registry, *not* this run's results — pruning on the latter would erase every live `session.*` streak whenever the session phase is skipped.

## Verification

Live against the signed-in profile on an alternate CDP port, running the extraction body **parsed out of the source** rather than a hand-copy:

- Real home: **20 projects, 0 null names.**
- Synthetic DOM: the nameless-icon-first row resolves (old code → `null`), the nested `<tr>` doesn't hijack the name, and both decoy links are excluded — 2 projects, not 4.
- `designer doctor` now exits **0** through ci-health, where it reported `-1` for two months.
- `npm run check` clean; **96/96 tests pass** (19 new).

Probe Chrome shut down after; the user's `:9222` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
