### PR TITLE
chore(health): stop the drift PR from sweeping in streak.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ artifacts/*
 # daily-health probe evidence is small + worth keeping in git so a human
 # reviewer of a selectors-drift PR can see what the probe saw.
 !artifacts/health/
+# … but not the streak counter — ephemeral run state, persisted via the
+# actions/cache step in daily-health.yml, not evidence of anything.
+artifacts/health/streak.json
 logs/*.log
 .DS_Store
 


### PR DESCRIPTION
## What

One line in `.gitignore`: re-exclude `artifacts/health/streak.json` inside the re-included `artifacts/health/` directory.

## Why

The selectors-drift PR step in `daily-health.yml` commits `artifacts/health/*.json` as probe evidence for human review. That glob also matches `streak.json` — the consecutive-failure counter, which is ephemeral run state, already persisted across runs by the `actions/cache` restore/save steps. So a drift PR would carry a churny state file next to the real evidence.

Re-excluding a file inside a re-included directory is valid gitignore semantics. The cache and `upload-artifact` steps don't consult `.gitignore`, so streak persistence is untouched — only `git add` (via the drift PR's `add-paths`) stops picking it up.

Verified locally:
- `git check-ignore -v artifacts/health/streak.json` → matched by the new rule
- `git check-ignore artifacts/health/<date>.json` → still NOT ignored (evidence commits keep working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)