### PR TITLE
fix(health): repair live selector drift, revive the dead canary, and make the probe assert its own environment

### DIFF
--- a/.github/workflows/auto-heal.yml
+++ b/.github/workflows/auto-heal.yml
@@ -130,10 +130,12 @@ jobs:
           # (installed by the official Claude Code GitHub App, see #20).
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Re-probe needs the same canary the original run probed. Keep this
-          # mirror of daily-health.yml's value in sync if you swap canaries
-          # — both workflows reference the same project URL by convention.
-          DESIGNER_PROBE_PROJECT_URL: https://claude.ai/design/p/72e73856-7b63-4aed-b95a-caca5e3c0e05
+          # Re-probe needs the same canary the original run probed — verifying a
+          # patch against a different project proves nothing. This mirrors
+          # daily-health.yml's value, and `npm run preflight` now ASSERTS the two
+          # agree: they had drifted to two different (both deleted) projects
+          # while the comment claimed they were kept in sync by convention.
+          DESIGNER_PROBE_PROJECT_URL: https://claude.ai/design/p/9a2066ca-e9e4-4972-a294-560092e6a216
           # Pipe the triage output through env (not `${{ }}` substitution into
           # the shell command body) so an anchor-id with unexpected characters
           # cannot inject. auto-heal.ts also re-validates the id via

--- a/.github/workflows/daily-health.yml
+++ b/.github/workflows/daily-health.yml
@@ -43,11 +43,21 @@ jobs:
     # two steps can't drift apart. Keep it SINGLE-FILE: a multi-file project puts
     # its files behind a "N pages" switcher instead of a flat Design Files list, so
     # session.fileListScrape's flat text-scrape intermittently finds 0 filenames
-    # (the 4-file "designer smoke test" flaked that way). To swap: create a fresh
-    # one-file project, open its file, replace the URL, then
+    # (the 4-file "designer smoke test" flaked that way).
+    #
+    # A canary can be DELETED out from under the probe, and the URL keeps
+    # answering — claude.ai serves a "Project not found" body on the same
+    # /design/p/<uuid> path. Both previous canaries died that way and the
+    # session anchors went on being read as UI drift, so `npm run preflight`
+    # now opens this project and fails the job when it is gone. Replacing it is
+    # a real step, not a formality.
+    #
+    # To swap: create a fresh one-file project, open its file, replace the URL
+    # HERE AND in auto-heal.yml (preflight asserts the two match), then
     # `gh workflow run daily-health.yml` to verify green before the next cron.
+    # Current canary created 2026-08-02, single page (index.html).
     env:
-      DESIGNER_PROBE_PROJECT_URL: https://claude.ai/design/p/6c5115ec-b27c-46b8-a7d9-1b09df042eff
+      DESIGNER_PROBE_PROJECT_URL: https://claude.ai/design/p/9a2066ca-e9e4-4972-a294-560092e6a216
 
     steps:
       - name: Checkout

--- a/scripts/auto-heal.ts
+++ b/scripts/auto-heal.ts
@@ -157,8 +157,10 @@ interface ArtifactJson {
     results: ProbeResult[];
   };
   diagnostics?: { url: string; htmlBytes: number; screenshotPath?: string } | null;
-  canary?: { target: string; landedOn: string; error?: string } | null;
-  homeNav?: { target: string; landedOn: string; error?: string } | null;
+  // `landedElsewhere` (ci-health.navMatch) is true when the probe did not reach
+  // the URL it aimed at — the session results then describe some other page.
+  canary?: { target: string; landedOn: string; landedElsewhere?: boolean; error?: string } | null;
+  homeNav?: { target: string; landedOn: string; landedElsewhere?: boolean; error?: string } | null;
 }
 
 interface ProposeSelectorInput {

--- a/scripts/ci-health.ts
+++ b/scripts/ci-health.ts
@@ -226,11 +226,42 @@ function scrubArtifact(s: string): string {
     .replace(/\/home\/[^\/\s"]+/g, '/home/<redacted>');
 }
 
-function scrubNav(n: { target: string; landedOn: string; error?: string } | null): typeof n {
-  if (!n) return n;
+/**
+ * Redaction collapses every project UUID to the same `<redacted>` token, so a
+ * scrubbed `{target, landedOn}` pair cannot answer the one question a reader
+ * asks first: did the probe actually reach the project it aimed at? Two
+ * different projects and one project read identically.
+ *
+ * That ambiguity is not hypothetical. The canary project was deleted while five
+ * daily runs reported session anchors green, and the artifact could not say
+ * whether those anchors had been probing the canary or whatever project the
+ * shared debug Chrome happened to be parked on. So compare BEFORE scrubbing and
+ * record the verdict as its own field — it leaks nothing the URL didn't already
+ * disclose, and `landedElsewhere` is exactly the signal that distinguishes
+ * "claude.ai drifted" from "the probe measured the wrong page".
+ */
+export function navMatch(target: string, landedOn: string): boolean {
+  const idOf = (u: string): string | null => {
+    const m = u.match(/\/design\/p\/([0-9a-f-]{8,})/i);
+    return m?.[1] ? m[1].toLowerCase() : null;
+  };
+  const a = idOf(target);
+  const b = idOf(landedOn);
+  // Both project URLs: same project or not. Otherwise fall back to comparing
+  // the path-only forms, so the home phase (no /p/ segment) still gets a verdict.
+  if (a && b) return a === b;
+  const pathOnly = (u: string): string => u.replace(/[?#].*$/, '').replace(/\/+$/, '');
+  return pathOnly(target) === pathOnly(landedOn);
+}
+
+function scrubNav(
+  n: { target: string; landedOn: string; error?: string } | null
+): (NonNullable<typeof n> & { landedElsewhere: boolean }) | null {
+  if (!n) return null;
   return {
     target: scrubArtifact(n.target),
     landedOn: scrubArtifact(n.landedOn),
+    landedElsewhere: !navMatch(n.target, n.landedOn),
     ...(n.error !== undefined ? { error: scrubArtifact(n.error) } : {})
   };
 }
@@ -498,6 +529,18 @@ async function main(): Promise<void> {
       const landedOn = (await browser.url().catch(() => '')) || '';
       sessionNav = { target: probeUrl, landedOn };
       console.log(`[ci-health] navigated to canary — landed=${landedOn}`);
+      // A silent redirect is the difference between "claude.ai drifted" and
+      // "we measured a different project". A deleted canary still answers on
+      // its own /design/p/<uuid> URL with a "Project not found" body, so the
+      // URL alone will not catch that — but a redirect elsewhere is caught
+      // here, and the readiness wait above already failed loudly for the
+      // not-found case. Warn rather than throw: the anchors' own verdicts
+      // remain the contract, this just stops them being read as canary truth.
+      if (!navMatch(probeUrl, landedOn)) {
+        console.log(
+          `::warning title=canary navigation landed elsewhere::session anchors did NOT probe DESIGNER_PROBE_PROJECT_URL — every session.* result below describes a different page. Fix the canary before reading them as claude.ai drift.`
+        );
+      }
     } catch (e) {
       sessionNav = { target: probeUrl, landedOn: '', error: (e as Error).message };
       console.log(`[ci-health] canary navigation failed — ${(e as Error).message}; session anchors will fail loudly`);

--- a/scripts/ci-preflight.ts
+++ b/scripts/ci-preflight.ts
@@ -78,14 +78,92 @@ function report(ok: boolean, name: string, detail: string): void {
 }
 
 // 3. Canary project URL is set and well-formed (the session/share anchors need it).
+const canaryUrl = process.env.DESIGNER_PROBE_PROJECT_URL ?? '';
 {
-  const url = process.env.DESIGNER_PROBE_PROJECT_URL ?? '';
-  const ok = /^https:\/\/claude\.ai\/design\/p\/[a-f0-9-]+/i.test(url);
-  report(ok, 'canary project URL', ok ? url : `"${url}" (expected https://claude.ai/design/p/<uuid>)`);
+  const ok = /^https:\/\/claude\.ai\/design\/p\/[a-f0-9-]+/i.test(canaryUrl);
+  report(ok, 'canary project URL', ok ? canaryUrl : `"${canaryUrl}" (expected https://claude.ai/design/p/<uuid>)`);
   if (!ok) {
     failures.push(
-      `DESIGNER_PROBE_PROJECT_URL is unset or malformed ("${url}") — the session.* / share.* anchors can't be exercised. ` +
+      `DESIGNER_PROBE_PROJECT_URL is unset or malformed ("${canaryUrl}") — the session.* / share.* anchors can't be exercised. ` +
         `Set it to a stable single-file canary project.`
+    );
+  }
+}
+
+// 4. The canary project still EXISTS.
+//
+// Shape was the only thing checked here until 2026-08-02, and shape survives
+// deletion: a deleted project keeps answering on its own /design/p/<uuid> URL,
+// serving a "Project not found" body. Both canaries had in fact been deleted
+// while the preflight passed — so the session anchors were being read as UI
+// drift when the real cause was that the page under them was gone. A dead
+// canary is an ENVIRONMENT failure, which is precisely what this file exists
+// to separate from claude.ai drift.
+//
+// Checked through the live CDP Chrome rather than a bare fetch: claude.ai/design
+// is a signed-in SPA, so an unauthenticated request cannot distinguish
+// "deleted" from "not logged in".
+if (canaryUrl && !failures.length) {
+  const { createBrowser } = await import('../browser.ts');
+  const NOT_FOUND_RE = /project not found|may have been deleted|you might not have access/i;
+  let ok = false;
+  let detail = canaryUrl;
+  try {
+    const browser = createBrowser({ session: 'designer-default', timeoutMs: 20_000 });
+    await browser.open(canaryUrl);
+    // The composer is the session-phase readiness marker every session anchor
+    // needs; waiting on it also gives the SPA time to render the not-found body.
+    await browser.waitFor('[data-testid="chat-composer-input"]').catch(() => undefined);
+    const probe = await browser
+      .evalValue<{ text: string; composer: boolean }>(
+        `(() => ({ text: (document.body ? document.body.innerText : '').slice(0, 400),
+                   composer: !!document.querySelector('[data-testid="chat-composer-input"]') }))()`
+      )
+      .catch(() => null);
+    if (!probe) {
+      detail = `${canaryUrl} — could not read the page`;
+    } else if (NOT_FOUND_RE.test(probe.text)) {
+      detail = `${canaryUrl} — claude.ai says the project is gone`;
+    } else if (!probe.composer) {
+      detail = `${canaryUrl} — loaded, but no chat composer rendered`;
+    } else {
+      ok = true;
+      detail = `${canaryUrl} — loads, composer present`;
+    }
+  } catch (e) {
+    detail = `${canaryUrl} — ${(e as Error).message}`;
+  }
+  report(ok, 'canary project exists', detail);
+  if (!ok) {
+    failures.push(
+      `The canary project did not load a usable session (${detail}). Every session.* / share.* anchor would fail ` +
+        `for that reason alone — do NOT read those failures as UI drift. Create a fresh single-file project and ` +
+        `update DESIGNER_PROBE_PROJECT_URL in BOTH .github/workflows/daily-health.yml and auto-heal.yml.`
+    );
+  }
+}
+
+// 5. Both workflows name the SAME canary.
+//
+// auto-heal re-probes to decide whether its patch worked, and that verification
+// is only meaningful against the page the original probe measured. The two
+// values were kept in sync "by convention" and had silently diverged — pointing
+// at two different (both deleted) projects. Convention is not a check.
+{
+  const read = (wf: string): string | null => {
+    const p = path.join(repoRoot, '.github', 'workflows', wf);
+    if (!fs.existsSync(p)) return null;
+    const m = fs.readFileSync(p, 'utf8').match(/DESIGNER_PROBE_PROJECT_URL:\s*(\S+)/);
+    return m?.[1] ?? null;
+  };
+  const daily = read('daily-health.yml');
+  const heal = read('auto-heal.yml');
+  const ok = daily != null && heal != null && daily === heal;
+  report(ok, 'canary URL agrees across workflows', ok ? `both = ${daily}` : `daily-health=${daily ?? 'missing'} auto-heal=${heal ?? 'missing'}`);
+  if (!ok) {
+    failures.push(
+      `daily-health.yml and auto-heal.yml name different canary projects (${daily ?? 'missing'} vs ${heal ?? 'missing'}). ` +
+        `auto-heal verifies its patch by re-probing, so a mismatch verifies against the wrong page.`
     );
   }
 }

--- a/selectors.json
+++ b/selectors.json
@@ -1,10 +1,11 @@
 {
   "_notes": "Captured 2026-04-17 from Chrome 147 via CDP. Override at ~/.designer/selectors.override.json. Prefer data-testid over class names — Claude's styled-components classes (sc-xxx) are regenerated on every build.",
-  "_drift": "2026-07 re-drifted, re-captured live 2026-07-24 from Chrome 150 (signed-in profile). The home is STILL composer-driven, but every home selector that was keyed on a tag name or a visible label has moved onto a data-testid — so this capture keys on testids only. Changes vs the 2026-06 capture: (1) the composer is no longer a <textarea> at all — the home now renders ZERO textareas; it is a ProseMirror contenteditable <div data-testid=\"home-composer-input\">. _submitPrompt's contenteditable branch (synthetic paste) drives it. (2) The submit button gained data-testid=\"home-composer-send\"; it is the SAME element as button[title=\"Create\"], which is retained as a LEGACY branch in `homeLegacy` (see `_branches` — a comma-OR is not an ordered fallback). It is always enabled, so content — not enabled-ness — is the submit gate. (3) The creation-type cards moved to data-testid=\"carousel-type-<kind>\" and their LABELS churn independently ('Product prototype' → 'Prototype' → 'Mobile app design' across three captures) — key on the testid, never the label. The testids survived every rename. (4) Projects moved from a flat link list to a <section data-testid=\"projects-list\"> of <tr data-testid=\"project-row\">; the row's <a href=/design/p/<uuid>> is now an EMPTY overlay link — the name lives in the first <td> and on the anchor's aria-label, so listProjects must not read anchor text. Placeholder text still ROTATES ('Draft a one-page project brief', …) — never key a selector on it. `designer adopt` remains available to bind an already-open tab to a key.",
+  "_drift": "2026-07 re-drifted, re-captured live 2026-07-24 from Chrome 150 (signed-in profile). The home is STILL composer-driven, but every home selector that was keyed on a tag name or a visible label has moved onto a data-testid — so this capture keys on testids only. Changes vs the 2026-06 capture: (1) the composer is no longer a <textarea> at all — the home now renders ZERO textareas; it is a ProseMirror contenteditable <div data-testid=\"home-composer-input\">. _submitPrompt's contenteditable branch (synthetic paste) drives it. (2) The submit button gained data-testid=\"home-composer-send\"; it is the SAME element as button[title=\"Create\"], which is retained as a LEGACY branch in `homeLegacy` (see `_branches` — a comma-OR is not an ordered fallback). It is always enabled, so content — not enabled-ness — is the submit gate. (3) The creation-type cards moved to data-testid=\"carousel-type-<kind>\" and their LABELS churn independently ('Product prototype' → 'Prototype' → 'Mobile app design' across three captures) — key on the testid, never the label. The testids survived every rename. [SUPERSEDED 2026-08-01 — see _cards.] (4) Projects moved from a flat link list to a <section data-testid=\"projects-list\"> of <tr data-testid=\"project-row\">; the row's <a href=/design/p/<uuid>> is now an EMPTY overlay link — the name lives in the first <td> and on the anchor's aria-label, so listProjects must not read anchor text. Placeholder text still ROTATES ('Draft a one-page project brief', …) — never key a selector on it. `designer adopt` remains available to bind an already-open tab to a key.",
   "_urls": {
     "home": "https://claude.ai/design",
     "session": "https://claude.ai/design/p/{uuid}"
   },
+  "_cards": "Creation-type cards, re-captured live 2026-08-01 (Chrome 150) after home.wireframeButton + home.highFiButton failed five consecutive daily probes (PRs #138-#143). The `carousel-type-<kind>` testids are GONE — the home renders zero [data-testid*=carousel] nodes. The cards are now `<button class=\"om-grid-tile\" aria-label=\"<label>\">` inside `<div class=\"om-grid\">`, and the ONLY per-card identifier that is not a churning human label is the thumbnail's asset path: `<img class=\"om-grid-thumb\" src=\"/design/grid-thumbs/<kind>.<n>.jpg\">`. That <kind> slug is the same vocabulary the dead testids used, and it is stable across exactly the renames that broke the label anchors — the card labelled 'Mobile app design' today serves `prototype.0.jpg`, and it was 'Product prototype' then 'Prototype' in earlier captures. So the canonical selector keys on the slug via :has() (Chrome 105+; the probe's Chrome is 150) and the dead testids are retained as legacy branches so a rollback reports `degraded`, not `fail`. Never key these on aria-label or visible text: 13 tiles ship today (software, prototype, slides, document, resume, animation, object3d, research, email, pairing, diagram, flier, wireframe) and their labels have churned three times against zero slug changes. The cards remain OFF the create path — createSession folds fidelity into the seed prompt — so these two anchors are drift sentinels only, not a broken verb.",
   "_branches": "A comma-separated CSS list is NOT an ordered fallback. `document.querySelector('A, B')` returns the first element in DOCUMENT ORDER matching either branch — not A's match preferred over B's. Packing a legacy branch into a canonical selector therefore (1) can silently return the WRONG element at runtime, and (2) keeps a presence-only health anchor green after the canonical selector has rotted, which defeats the daily probe. So canonical selectors below are single-branch, and superseded forms live in `homeLegacy` / `loginLegacy`. Health checks canonical first and reports `degraded` (not `ok`) when only the legacy branch matches; runtime resolvers try them in explicit order.",
   "login": {
     "signedInIndicator": "[data-testid=\"chat-composer-input\"], [data-testid=\"home-composer-input\"]"
@@ -15,8 +16,8 @@
   "home": {
     "creator": "[data-testid=\"home-composer-input\"]",
     "nameInput": "[data-testid=\"home-composer-input\"]",
-    "wireframeButton": "[data-testid=\"carousel-type-wireframe\"]",
-    "highFiButton": "[data-testid=\"carousel-type-prototype\"]",
+    "wireframeButton": "button.om-grid-tile:has(img[src*=\"/grid-thumbs/wireframe.\"])",
+    "highFiButton": "button.om-grid-tile:has(img[src*=\"/grid-thumbs/prototype.\"])",
     "createButton": "[data-testid=\"home-composer-send\"]",
     "projectsList": "[data-testid=\"projects-list\"]",
     "projectCard": "[data-testid=\"project-row\"]",
@@ -25,7 +26,9 @@
   "homeLegacy": {
     "createButton": "button[title=\"Create\"]",
     "projectsList": "a[href*=\"/design/p/\"]",
-    "projectCard": "a[href*=\"/design/p/\"]"
+    "projectCard": "a[href*=\"/design/p/\"]",
+    "wireframeButton": "[data-testid=\"carousel-type-wireframe\"]",
+    "highFiButton": "[data-testid=\"carousel-type-prototype\"]"
   },
   "composer": {
     "promptTextarea": "[data-testid=\"chat-composer-input\"]",

--- a/selectors.ts
+++ b/selectors.ts
@@ -25,15 +25,18 @@ export interface Selectors {
     createButton?: string;
     projectsList?: string;
     projectCard?: string;
+    wireframeButton?: string;
+    highFiButton?: string;
   };
   composerLegacy?: { sendButton?: string };
   home: {
     creator: string;
     nameInput: string;
-    // Creation-type cards, keyed by data-testid. These were `*ButtonText` label
-    // literals until 2026-07: the labels churned three times ("Product prototype"
-    // → "Prototype" → "Mobile app design") while the testids never moved, so the
-    // contract is a selector now, not text to match.
+    // Creation-type cards. Twice re-keyed, each time onto whatever the product
+    // was NOT renaming: label literals → `carousel-type-<kind>` testids (2026-07)
+    // → the thumbnail asset slug `/grid-thumbs/<kind>.` (2026-08, when the
+    // testids were removed outright). The slug is the surviving name for a card
+    // whose label has now churned three times; see `_cards` in selectors.json.
     wireframeButton: string;
     highFiButton: string;
     createButton: string;

--- a/tests/health-apparatus.contract.test.mjs
+++ b/tests/health-apparatus.contract.test.mjs
@@ -3,7 +3,7 @@ import test from 'node:test';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { resolveDoctorBin, probeVerdict, EXIT_CODE } from '../scripts/ci-health.ts';
+import { resolveDoctorBin, probeVerdict, EXIT_CODE, navMatch } from '../scripts/ci-health.ts';
 import { findAnchor, canPatch } from '../scripts/anchor-patcher.ts';
 import { classifyCandidates, isStructurallyBlind, patchableAnchorIds } from '../scripts/auto-heal.ts';
 import { orderedBranches, presenceSelector } from '../selectors.ts';
@@ -19,6 +19,34 @@ import { REPO_ROOT } from '../repo-root.ts';
 //     the inline string literals its AST patcher rewrites (#129 item 0).
 // The through-line: "never ran" was indistinguishable from "healthy". These
 // tests make each layer assert its own capability.
+
+// --- the artifact must say WHICH page it measured ---
+// Redaction maps every project UUID to the same `<redacted>` token, so a reader
+// of the committed artifact cannot tell a canary hit from a canary miss. That
+// ambiguity is why five green session phases could not be trusted once the
+// canary turned out to be deleted. navMatch is computed pre-redaction.
+
+test('navMatch distinguishes two different projects', () => {
+  const a = 'https://claude.ai/design/p/6c5115ec-b27c-46b8-a7d9-1b09df042eff';
+  const b = 'https://claude.ai/design/p/a9f7ac92-1cc3-480f-93b9-ea91d5ae55c5';
+  assert.equal(navMatch(a, b), false, 'landing on another project must not read as reaching the canary');
+  assert.equal(navMatch(a, a), true);
+});
+
+test('navMatch ignores query strings and case, which are not a different project', () => {
+  const bare = 'https://claude.ai/design/p/6C5115EC-b27c-46b8-a7d9-1b09df042eff';
+  const withFile = 'https://claude.ai/design/p/6c5115ec-b27c-46b8-a7d9-1b09df042eff?file=Page.html';
+  assert.equal(navMatch(bare, withFile), true, 'an opened file is the same project');
+});
+
+test('navMatch still decides the home phase, which has no /p/ segment', () => {
+  assert.equal(navMatch('https://claude.ai/design', 'https://claude.ai/design'), true);
+  assert.equal(navMatch('https://claude.ai/design', 'https://claude.ai/login?returnTo=%2Fdesign'), false);
+});
+
+test('a failed navigation (empty landedOn) never reads as a match', () => {
+  assert.equal(navMatch('https://claude.ai/design/p/6c5115ec-b27c-46b8-a7d9-1b09df042eff', ''), false);
+});
 
 // --- #130: the doctor spawn path ---
 

--- a/tests/health-apparatus.switcher.test.mjs
+++ b/tests/health-apparatus.switcher.test.mjs
@@ -35,3 +35,83 @@ test('the switcher anchor SKIPS when the page is not a project at all', async ()
   assert.equal(r.ok, true);
   assert.equal(r.status, 'skip', 'no project surface is genuinely inconclusive');
 });
+
+/**
+ * Page stub where TRUSTED clicks do nothing and only a synthetic `el.click()`
+ * actuates — the live 2026-08-01 behaviour of claude.ai/design. Production's
+ * deleteFile has always fallen back to a synthetic click; this probe did not,
+ * so it failed five consecutive daily runs (#138-#143) while deletion worked.
+ *
+ * The stub tracks whether each surface was opened synthetically, so a probe that
+ * only issues trusted clicks can never reach the menu.
+ */
+const trustedClickIsDead = ({ menuItems = ['Download', 'Delete'] } = {}) => {
+  const state = { popoverOpen: false, menuOpen: false, trustedClicks: 0, syntheticClicks: 0 };
+  const browser = {
+    state,
+    url: async () => 'https://claude.ai/design/p/abc12345-1111-2222-3333-444455556666',
+    hover: async () => '',
+    press: async () => {
+      state.menuOpen = false;
+      state.popoverOpen = false;
+      return '';
+    },
+    // Trusted click: counted, deliberately inert.
+    click: async () => {
+      state.trustedClicks += 1;
+      return '';
+    },
+    isVisible: async () => state.popoverOpen,
+    evalValue: async (expr) => {
+      // Synthetic opener for the popover (clickTriggerExpr) and for the row menu.
+      if (expr.includes("return 'clicked'")) {
+        state.syntheticClicks += 1;
+        if (expr.includes('files-switcher-trigger')) state.popoverOpen = true;
+        else state.menuOpen = true;
+        return 'clicked';
+      }
+      if (expr.includes('!!document.querySelector') && expr.includes('files-switcher-trigger')) return true;
+      // switcherStateExpr
+      if (expr.includes("return 'open'") && expr.includes("return 'closed'")) {
+        return state.popoverOpen ? 'open' : 'closed';
+      }
+      // readRowsExpr
+      if (expr.includes('mount-read')) {
+        return { rows: state.popoverOpen ? [{ label: 'Page', editedText: 'Edited 1h ago' }] : [], reused: false };
+      }
+      // stampRowExpr
+      if (expr.includes("'stamped'") && expr.includes('data-designer-target="row"')) {
+        return state.popoverOpen ? 'stamped' : 'no-row:0';
+      }
+      // Row-count cardinality read.
+      if (expr.includes('.length') && expr.includes('files-switcher-row')) return state.popoverOpen ? 1 : 0;
+      // readItems inside probeRowMenu.
+      if (expr.includes('[role="menu"] [role="menuitem"]')) return state.menuOpen ? menuItems : [];
+      // stampMenuDeleteExpr
+      if (expr.includes("'no-menu'")) {
+        if (!state.menuOpen) return 'no-menu';
+        return menuItems.filter((t) => t === 'Delete').length === 1 ? 'stamped' : `items:${menuItems.join('|')}`;
+      }
+      return null;
+    }
+  };
+  return browser;
+};
+
+test('the switcher probe opens the row menu synthetically when the trusted click no-ops', async () => {
+  const b = trustedClickIsDead();
+  const r = await anchor.check(b, '');
+  assert.equal(r.ok, true, 'a page where only synthetic clicks land is what production already handles');
+  assert.ok(b.state.trustedClicks > 0, 'the trusted click is still tried FIRST');
+  assert.ok(b.state.syntheticClicks > 0, 'the synthetic fallback is what actually opens the menu');
+  assert.match(r.detail, /synthetic fallback/, 'the report says the trusted click no-opped rather than hiding it');
+});
+
+test('the switcher probe still FAILS when neither click opens the menu', async () => {
+  // The fallback must not become a way to pass without ever seeing a menu.
+  const b = trustedClickIsDead();
+  const inert = { ...b, evalValue: async (expr) => (expr.includes("return 'clicked'") && !expr.includes('files-switcher-trigger') ? 'absent' : b.evalValue(expr)) };
+  const r = await anchor.check(inert, '');
+  assert.equal(r.ok, false, 'no menu by any means is real drift');
+  assert.match(r.detail, /no role=menu items/);
+});

--- a/tests/ui-drift.matchers.test.mjs
+++ b/tests/ui-drift.matchers.test.mjs
@@ -145,19 +145,46 @@ test('home.creator probes the composer testid, not a bare <textarea> tag', async
   assert.equal((await anchor('home.creator').check(onTagOnly, 'https://claude.ai/design')).ok, false);
 });
 
-test('home creation-type cards probe carousel testids, so a label rename cannot break them', async () => {
+// 2026-08-01: the carousel testids were removed outright, so the cards are keyed
+// on the thumbnail asset slug (/grid-thumbs/<kind>.) — the only per-card name the
+// product has never renamed. These lock in that contract the same way.
+test('home creation-type cards probe the thumbnail slug, so a label rename cannot break them', async () => {
+  for (const [id, slug] of [
+    ['home.highFiButton', 'grid-thumbs/prototype\\.'],
+    ['home.wireframeButton', 'grid-thumbs/wireframe\\.']
+  ]) {
+    const onSlug = stubBrowser((expr) => new RegExp(slug).test(expr));
+    const r = await anchor(id).check(onSlug, 'https://claude.ai/design');
+    assert.equal(r.ok, true, `${id} matches ${slug}`);
+    assert.notEqual(r.status, 'degraded', `${id} on the canonical slug is plain ok, not degraded`);
+
+    // Labels churn independently of the slug — "Mobile app design" is the third
+    // label on the card the slug still calls `prototype`. A probe that only sees
+    // visible text must fail, or the anchor is label-keyed again.
+    const onLabelOnly = stubBrowser((expr) => /Prototype|Wireframe|Mobile app design/.test(expr));
+    assert.equal((await anchor(id).check(onLabelOnly, 'https://claude.ai/design')).ok, false, `${id} is not label-keyed`);
+  }
+});
+
+test('a carousel-testid rollback reports degraded, not ok and not fail', async () => {
+  // The dead testids are retained as legacy branches purely so this case is
+  // distinguishable: the tool would still work, but the canonical contract is
+  // broken and must not read green.
   for (const [id, testid] of [
     ['home.highFiButton', 'carousel-type-prototype'],
     ['home.wireframeButton', 'carousel-type-wireframe']
   ]) {
-    const onTestid = stubBrowser((expr) => new RegExp(testid).test(expr));
-    assert.equal((await anchor(id).check(onTestid, 'https://claude.ai/design')).ok, true, `${id} matches ${testid}`);
+    const onLegacyOnly = stubBrowser((expr) => new RegExp(testid).test(expr));
+    const r = await anchor(id).check(onLegacyOnly, 'https://claude.ai/design');
+    assert.equal(r.ok, true, `${id} still resolves via the legacy testid`);
+    assert.equal(r.status, 'degraded', `${id} on the legacy branch alone must be degraded`);
+  }
+});
 
-    // Labels churn independently of the testids — a probe that only sees the old
-    // visible text must fail, and one that only sees the NEW text must not be
-    // required either. Neither label is load-bearing.
-    const onLabelOnly = stubBrowser((expr) => /Prototype|Wireframe|Mobile app design/.test(expr));
-    assert.equal((await anchor(id).check(onLabelOnly, 'https://claude.ai/design')).ok, false, `${id} is not label-keyed`);
+test('creation-type cards fail when neither the slug nor the legacy testid is present', async () => {
+  for (const id of ['home.highFiButton', 'home.wireframeButton']) {
+    const onNothing = stubBrowser(() => false);
+    assert.equal((await anchor(id).check(onNothing, 'https://claude.ai/design')).ok, false, `${id} fails when gone`);
   }
 });
 

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -431,6 +431,15 @@ export const UI_ANCHORS: AnchorDef[] = [
   // So the creation-type cards are selector anchors now, not text matchers. The
   // old home.nameInput anchor stays dropped (no equivalent). The cards remain off
   // the create path (they only set the Template pill) — drift sentinels only.
+  //
+  // 2026-08-01: the `carousel-type-*` testids were then removed outright (five
+  // consecutive drift PRs, #138-#143 — the home now renders zero
+  // [data-testid*=carousel] nodes). Re-keyed onto the one per-card identifier the
+  // renames do not touch: the thumbnail asset slug, `img.om-grid-thumb[src*=
+  // "/grid-thumbs/<kind>."]`. That slug reuses the dead testids' own vocabulary,
+  // so `prototype` still names the card whose visible label is now "Mobile app
+  // design". The dead testids move to homeLegacy, which makes a rollback read
+  // `degraded` instead of `fail`. See `_cards` in selectors.json for the capture.
   {
     id: 'home.creator',
     category: 'home',
@@ -441,16 +450,18 @@ export const UI_ANCHORS: AnchorDef[] = [
   {
     id: 'home.wireframeButton',
     category: 'home',
-    description: 'Wireframe creation-type card ([data-testid="carousel-type-wireframe"])',
+    description: 'Wireframe creation-type card (thumbnail slug /grid-thumbs/wireframe.)',
     requires: 'home',
-    check: async (b) => ({ ok: await hasSelector(b, SEL.home.wireframeButton) })
+    check: async (b) =>
+      checkWithLegacy(b, SEL.home.wireframeButton, SEL.homeLegacy?.wireframeButton, 'home.wireframeButton')
   },
   {
     id: 'home.highFiButton',
     category: 'home',
-    description: 'Prototype creation-type card ([data-testid="carousel-type-prototype"])',
+    description: 'Prototype creation-type card (thumbnail slug /grid-thumbs/prototype.)',
     requires: 'home',
-    check: async (b) => ({ ok: await hasSelector(b, SEL.home.highFiButton) })
+    check: async (b) =>
+      checkWithLegacy(b, SEL.home.highFiButton, SEL.homeLegacy?.highFiButton, 'home.highFiButton')
   },
   {
     id: 'home.createButton',

--- a/ui-anchors.ts
+++ b/ui-anchors.ts
@@ -188,15 +188,40 @@ async function probeRowMenu(
     return { ok: false, detail: `row actions did not reveal on hover (${SEL.files.rowMoreActions} not visible)` };
   }
 
+  // Open the menu the way PRODUCTION opens it: trusted click, then a synthetic
+  // fallback. deleteFile has had that fallback all along; this probe had only
+  // the trusted half, so when trusted clicks stopped actuating these controls
+  // the probe failed daily (#138-#143) while deletion kept working — a probe
+  // STRICTER than production, which is the PR #77 split running the other way.
+  // The synthetic click is safe here for the same reason clickTriggerExpr is:
+  // opening a menu is not destructive. Delete is still never clicked.
+  const readItems = async (): Promise<string[]> =>
+    (await b
+      .evalValue<string[]>(
+        `(() => Array.from(document.querySelectorAll('[role="menu"] [role="menuitem"], [role="menu"] button'))
+           .map((e) => (e.textContent || '').trim()).filter(Boolean))()`
+      )
+      .catch(() => [] as string[])) || [];
+
   await b.click(moreSel).catch(() => null);
   await sleep(600);
-  const items = await b
-    .evalValue<string[]>(
-      `(() => Array.from(document.querySelectorAll('[role="menu"] [role="menuitem"], [role="menu"] button'))
-         .map((e) => (e.textContent || '').trim()).filter(Boolean))()`
-    )
-    .catch(() => [] as string[]);
-  if (items.length === 0) return { ok: false, detail: 'row "More actions" opened no role=menu items' };
+  let items = await readItems();
+  let openedSynthetically = false;
+  if (items.length === 0) {
+    const res = await b
+      .evalValue<string>(
+        `(() => { const e = document.querySelector(${JSON.stringify(moreSel)}); if (!e) return 'absent'; e.click(); return 'clicked'; })()`
+      )
+      .catch(() => 'error');
+    await sleep(800);
+    if (res === 'clicked') {
+      items = await readItems();
+      openedSynthetically = items.length > 0;
+    }
+  }
+  if (items.length === 0) {
+    return { ok: false, detail: 'row "More actions" opened no role=menu items (trusted click and synthetic fallback both)' };
+  }
   if (!items.includes(MENU_ITEM_DOWNLOAD)) {
     return { ok: false, detail: `row menu missing "${MENU_ITEM_DOWNLOAD}" (items: ${items.join(', ')})` };
   }
@@ -207,8 +232,9 @@ async function probeRowMenu(
   // deletion refused with 'menu-unavailable'. Run the real resolver — it only
   // stamps an attribute, it never clicks. #F9.
   const menuResolves = await b.evalValue<string>(stampMenuDeleteExpr()).catch(() => 'error');
+  const opener = openedSynthetically ? '; opened via the synthetic fallback (trusted click no-opped)' : '';
   if (menuResolves === 'stamped') {
-    return { ok: true, detail: `${entryCount} row(s); menu offers ${items.join(', ')}` };
+    return { ok: true, detail: `${entryCount} row(s); menu offers ${items.join(', ')}${opener}` };
   }
   if (items.includes(MENU_ITEM_DELETE)) {
     return {
@@ -223,7 +249,7 @@ async function probeRowMenu(
     return {
       ok: true,
       status: 'degraded',
-      detail: `single-page project — no "${MENU_ITEM_DELETE}" item offered (items: ${items.join(', ')})`
+      detail: `single-page project — no "${MENU_ITEM_DELETE}" item offered (items: ${items.join(', ')})${opener}`
     };
   }
   return { ok: false, detail: `row menu missing "${MENU_ITEM_DELETE}" (items: ${items.join(', ')})` };


### PR DESCRIPTION
Five consecutive daily probes (#138, #139, #140, #141, #143) reported the same three anchors down. All three were real, none had the cause the drift PRs implied, and one of them was not claude.ai's fault at all.

Everything below was found by driving the live product through the repo's own probe (Chrome 150, signed-in profile, 2026-08-02), not by reading the artifacts.

## What was actually broken

**1. The creation-type cards lost their testids.** `home.wireframeButton` / `home.highFiButton` keyed on `[data-testid="carousel-type-*"]`. The home now renders **zero** `[data-testid*=carousel]` nodes. The cards are still there as `button.om-grid-tile`, carrying only an `aria-label`.

Re-keying on that label is what broke these anchors the *last* time — the labels have churned three times ("Product prototype" → "Prototype" → "Mobile app design") against zero testid moves. So this keys on the one per-card identifier that has never moved: the thumbnail asset path.

```
"UI mockups"        →  /design/grid-thumbs/software.0.jpg
"Mobile app design" →  /design/grid-thumbs/prototype.0.jpg   ← the card the contract calls `prototype`
"Wireframe"         →  /design/grid-thumbs/wireframe.0.jpg
```

That slug reuses the dead testids' own vocabulary, which is what lets us say the card labelled "Mobile app design" today is the same card `carousel-type-prototype` named. The dead testids move to `homeLegacy`, so a rollback reports `degraded`, not `fail`.

These cards are off the create path — `createSession` folds fidelity into the seed prompt — so this restores a drift sentinel; it does not unbreak a verb.

**2. The switcher probe was stricter than production.** `session.filesSwitcher` failed with `row "More actions" opened no role=menu items`. The menu was fine. Trusted (CDP-dispatched) clicks intermittently do not actuate these controls — I reproduced it live, with `aria-expanded` staying `false` on both the switcher trigger and More actions while a synthetic `el.click()` opened both.

`deleteFile` has always handled this: click, check whether the menu really opened, fall back to synthetic. `probeRowMenu` had only the trusted half, so **the probe reported drift while deletion kept working** — the PR #77 probe/production split running in the opposite direction. The probe now uses the same two-step actuation and records in its detail when the fallback was what worked.

**3. Both canary projects are deleted — and CI could not tell.** This is the one that was never claude.ai's fault.

`daily-health.yml` pointed at `6c5115ec…`; `auto-heal.yml` pointed at a **different** project, `72e73856…`. The comment claimed they were kept in sync "by convention". They had diverged, and both now answer `Project not found`.

Nothing caught it, because the preflight only checked the URL's **shape** — and shape survives deletion. A deleted project keeps serving on its own `/design/p/<uuid>` path. So session anchors were failing for an environment reason while being read as UI drift, which is precisely the confusion `ci-preflight.ts` exists to prevent.

The artifact could not settle it either: redaction maps every project UUID to the same `<redacted>` token, so "reached the canary" and "landed on some other project" read identically.

## Changes

| Area | Change |
|---|---|
| `selectors.json` / `selectors.ts` | Cards keyed on the thumbnail slug; dead testids retained as `homeLegacy` branches; new `_cards` capture note |
| `ui-anchors.ts` | Both card anchors use `checkWithLegacy`; `probeRowMenu` gains production's synthetic fallback |
| `ci-preflight.ts` | Opens the canary through live CDP Chrome and fails the job when it is gone; asserts both workflows name the same project |
| `ci-health.ts` | `navMatch` computed **before** redaction → new `landedElsewhere` field, plus a `::warning` when the session phase lands elsewhere |
| Both workflows | Fresh single-file canary (`9a2066ca…`, created 2026-08-02, one page) |

The canary liveness check goes through Chrome rather than a bare fetch: claude.ai/design is a signed-in SPA, so an unauthenticated request cannot distinguish "deleted" from "not logged in".

## Evidence

| Check | Before | After |
|---|---|---|
| Full CI probe (`probe:health`) | 24 ok / **3 fail** | **26 ok / 0 degraded / 0 fail** / 1 skip |
| Preflight, deleted canary | exit 0 (passed) | **exit 1**, named as environment failure |
| Preflight, new canary | — | exit 0, "loads, composer present" |
| Unit tests | 218 | **222 pass** |
| Typecheck / build | clean | clean |

`session.filesSwitcher` is green live on both a 1-file and a 6-file project.

**One honest gap:** the synthetic-fallback *path* is proven by unit test, not by the live runs. Locally the trusted click usually succeeds, so the live runs exercised the trusted path. The fallback's behaviour — trusted first, synthetic only if no menu appeared, still failing when neither works — is covered deterministically in `tests/health-apparatus.switcher.test.mjs`.

## On #129

Most of it had already shipped in #131/#134 — the ordered legacy branches, `degraded` reporting, the per-uuid candidate collection, the explicit `closest()` order, pathname parsing, and streak-orphan pruning are all in `main` today. I re-verified each against the code rather than trusting the issue text.

What remains is **item 0.3, patcher V2**: auto-heal still cannot patch a single anchor. I confirmed this against the real file — every anchor reads `SEL.group.key`, and the AST patcher only rewrites string literals. Today's drift is exactly what V2 would have healed. That is deliberately **not** in this PR; it mutates the shared contract every consumer reads and wants its own dry-run gate. Item 6b (a completeness signal for a virtualized project list) is also still open.

So this closes the drift PRs, and #129 stays open on those two items.

Closes #138
Closes #139
Closes #140
Closes #141
Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)