### PR TITLE
fix(setup): match Chrome by process name, not command line

### DIFF
--- a/cross-platform.ts
+++ b/cross-platform.ts
@@ -41,19 +41,50 @@ export function defaultChromeBin(): string {
   return '/usr/bin/google-chrome';
 }
 
+// Process NAMES a real Chrome/Chromium main process carries on Linux, as an
+// anchored `pgrep -x` alternation. Two constraints shaped this list (#114):
+//
+//  - Linux truncates a process name to 15 chars, so `chromium-browser` is only
+//    ever visible as `chromium-browse`. Matching the untruncated spelling finds
+//    nothing.
+//  - The names must stay near-miss free, because `setup.ts` treats a match as
+//    "a non-debug Chrome is running", polls five minutes, then hard-fails. The
+//    excluded neighbours are `chromedriver`, `chrome-sandbox`, and
+//    `chrome_crashpad` (itself the truncation of `chrome_crashpad_handler`,
+//    which can outlive a Chrome quit).
+//
+// Verified on debian:stable-slim + procps against processes carrying each name.
+export const LINUX_CHROME_PROCESS_NAMES = 'chrome|chromium|chromium-browse|google-chrome';
+
+// The probe argv behind isChromeRunning(), separated so the per-OS decision is
+// testable without spawning anything. Takes the platform explicitly so one test
+// process can assert all three branches.
+export function chromeRunningProbe(platform: NodeJS.Platform = process.platform): {
+  cmd: string;
+  args: string[];
+} {
+  if (platform === 'win32') {
+    return { cmd: 'tasklist', args: ['/FI', 'IMAGENAME eq chrome.exe', '/NH', '/FO', 'CSV'] };
+  }
+  if (platform === 'darwin') {
+    // Full-path match: specific enough that no near-miss collides.
+    return { cmd: 'pgrep', args: ['-f', 'Google Chrome.app/Contents/MacOS/Google Chrome'] };
+  }
+  // `-x` anchors against the process NAME. The previous `-f chrome` matched the
+  // whole command line, which both over-matched (any argv naming a chrome* file
+  // blocked setup for five minutes) and under-matched (`chromium` does not
+  // contain the substring `chrome`, so a real Chromium was never detected).
+  return { cmd: 'pgrep', args: ['-x', LINUX_CHROME_PROCESS_NAMES] };
+}
+
 // Cross-platform "is a non-debug Chrome currently running?" check.
 export function isChromeRunning(): boolean {
+  const { cmd, args } = chromeRunningProbe();
+  const r = nodeSpawnSync(cmd, args, { stdio: 'pipe' });
   if (IS_WIN) {
-    const r = nodeSpawnSync('tasklist', ['/FI', 'IMAGENAME eq chrome.exe', '/NH', '/FO', 'CSV'], { stdio: 'pipe' });
     if (r.status !== 0) return false;
-    const out = r.stdout?.toString() || '';
-    return out.toLowerCase().includes('chrome.exe');
+    return (r.stdout?.toString() || '').toLowerCase().includes('chrome.exe');
   }
-  if (IS_MAC) {
-    const r = nodeSpawnSync('pgrep', ['-f', 'Google Chrome.app/Contents/MacOS/Google Chrome'], { stdio: 'pipe' });
-    return r.status === 0 && (r.stdout?.toString().trim().length ?? 0) > 0;
-  }
-  const r = nodeSpawnSync('pgrep', ['-f', 'chrome'], { stdio: 'pipe' });
   return r.status === 0 && (r.stdout?.toString().trim().length ?? 0) > 0;
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cli": "tsx cli.ts",
     "setup": "tsx cli.ts setup",
     "doctor": "tsx cli.ts doctor",
-    "test": "npm run build && node --test tests/cli-metadata.test.mjs && node --import tsx --test tests/run-state.*.test.mjs tests/cdp-trace.*.test.mjs tests/ui-drift.*.test.mjs tests/interstitials.*.test.mjs tests/health-apparatus.*.test.mjs tests/cdp-dialog.*.test.mjs tests/files-switcher.*.test.mjs tests/cli-consent.*.test.mjs tests/controller-lock.*.test.mjs",
+    "test": "npm run build && node --test tests/cli-metadata.test.mjs && node --import tsx --test tests/run-state.*.test.mjs tests/cdp-trace.*.test.mjs tests/ui-drift.*.test.mjs tests/interstitials.*.test.mjs tests/health-apparatus.*.test.mjs tests/cdp-dialog.*.test.mjs tests/files-switcher.*.test.mjs tests/cli-consent.*.test.mjs tests/controller-lock.*.test.mjs tests/cross-platform.*.test.mjs",
     "check": "tsc --noEmit",
     "build": "tsc -p tsconfig.build.json",
     "prepack": "npm run check && npm run build",

--- a/tests/cross-platform.chrome-probe.test.mjs
+++ b/tests/cross-platform.chrome-probe.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { chromeRunningProbe, LINUX_CHROME_PROCESS_NAMES } from '../cross-platform.ts';
+
+// Regression coverage for #114: on Linux the probe was `pgrep -f chrome`, which
+// matches the whole command line. setup.ts treats a match as "a non-debug Chrome
+// is running", then polls for five minutes and hard-fails — so a stray
+// chromedriver made `designer setup` unusable, and quitting Chrome could not fix
+// it because Chrome was never what matched.
+//
+// The names and truncations asserted below were observed on debian:stable-slim
+// with procps, running one process per name.
+
+// Stand-in for `pgrep -x <ere>`: anchored match against the process NAME.
+const pgrepExactMatches = (name) => new RegExp(`^(?:${LINUX_CHROME_PROCESS_NAMES})$`).test(name);
+
+test('the Linux probe anchors on the process name, not the command line', () => {
+  const { cmd, args } = chromeRunningProbe('linux');
+  assert.equal(cmd, 'pgrep');
+  assert.ok(args.includes('-x'), 'must use -x (name match)');
+  assert.ok(!args.includes('-f'), '-f matches the full command line and reintroduces #114');
+});
+
+test('a real Chrome or Chromium main process still matches', () => {
+  // `chromium-browse` is what Linux reports for chromium-browser: process names
+  // truncate at 15 chars, so the untruncated spelling would match nothing.
+  for (const name of ['chrome', 'chromium', 'chromium-browse', 'google-chrome']) {
+    assert.equal(pgrepExactMatches(name), true, name);
+  }
+});
+
+test('near-miss processes no longer block setup', () => {
+  // chrome_crashpad is itself the 15-char truncation of chrome_crashpad_handler,
+  // which can outlive a Chrome quit — the case that made the timeout unfixable.
+  for (const name of ['chromedriver', 'chrome-sandbox', 'chrome_crashpad', 'chrome_crashpad_handler']) {
+    assert.equal(pgrepExactMatches(name), false, name);
+  }
+});
+
+test('an editor or shell merely naming a chrome file does not match', () => {
+  for (const name of ['vim', 'node', 'bash']) assert.equal(pgrepExactMatches(name), false, name);
+});
+
+test('the macOS and Windows branches are unchanged', () => {
+  const mac = chromeRunningProbe('darwin');
+  assert.equal(mac.cmd, 'pgrep');
+  assert.deepEqual(mac.args, ['-f', 'Google Chrome.app/Contents/MacOS/Google Chrome']);
+
+  const win = chromeRunningProbe('win32');
+  assert.equal(win.cmd, 'tasklist');
+  assert.deepEqual(win.args, ['/FI', 'IMAGENAME eq chrome.exe', '/NH', '/FO', 'CSV']);
+});


### PR DESCRIPTION
Closes #114.

## The bug

`isChromeRunning()` probed Linux with `pgrep -f chrome`, which matches the full
command line. `setup.ts` reads a match as "a non-debug Chrome is running", polls
for five minutes, then hard-fails — and the user cannot clear it by quitting
Chrome, because Chrome was never what matched. A stray `chromedriver` was enough
to make `designer setup` unusable.

The same line also **under**-matched: `chromium` does not contain the substring
`chrome`, so a real Chromium was never detected at all. That half wasn't in the
issue; it showed up when I ran the probe rather than reasoning about it.

## The fix

Probe the process **name** through an anchored `pgrep -x` alternation. The per-OS
argv moves into `chromeRunningProbe(platform)` so the decision is testable
without spawning anything. macOS and Windows branches are unchanged.

Two details came from the container, not from the compiler:

- Linux truncates process names at 15 characters, so `chromium-browser` is only
  ever visible as `chromium-browse`. The issue's suggested `pgrep -x 'chrome|chromium'`
  would have missed it, and `google-chrome` too.
- `chrome_crashpad_handler` appears as `chrome_crashpad`, and it can outlive a
  Chrome quit — the case that made the five-minute timeout unfixable.

## Verification

`debian:stable-slim` + `procps`, one process per name:

| scenario | old `-f chrome` | new `-x` names |
|---|---|---|
| only `chromedriver`, zero Chrome (the issue's repro) | RUNNING | not running |
| `chrome_crashpad_handler` outliving a Chrome quit | RUNNING | not running |
| a real `chrome` running | RUNNING | RUNNING |
| a real `chromium` running | not running | RUNNING |

Locally: `npm run check` clean, `npm test` 249 pass / 0 fail.

## Notes

- Five regression tests added, and the `cross-platform.*` prefix registered in the
  `npm test` glob — without that a new prefix silently never runs.
- `scripts/designer-chrome.sh` carries the same pattern for a non-fatal warning and
  is left alone here; #110 rewrites that file to be OS-aware.
- No Linear ticket — this repo tracks work in GitHub issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)