### PR TITLE
fix(setup): give the launcher script the same Chrome probe as the CLI

### DIFF
--- a/scripts/designer-chrome.sh
+++ b/scripts/designer-chrome.sh
@@ -33,8 +33,21 @@ if curl -fs -o /dev/null "http://127.0.0.1:$PORT/json/version"; then
   exit 0
 fi
 
-if [ "$(uname -s)" = "Darwin" ]; then CHROME_PAT="Google Chrome"; QUIT_HINT="Quit existing Chrome (Cmd+Q) first"; else CHROME_PAT="chrome"; QUIT_HINT="Quit existing Chrome (or 'pkill chrome') first"; fi
-if pgrep -f "$CHROME_PAT" >/dev/null; then
+# Same probe shape as isChromeRunning() in cross-platform.ts (#114): on Linux
+# match the process NAME, because `pgrep -f chrome` scans the whole command line
+# — it warns on a stray chromedriver or a leftover chrome_crashpad, and misses a
+# real chromium (which has no "chrome" substring). Names truncate at 15 chars, so
+# chromium-browser is only ever visible as chromium-browse.
+if [ "$(uname -s)" = "Darwin" ]; then
+  CHROME_PAT="Google Chrome"
+  PGREP_MODE="-f"
+  QUIT_HINT="Quit existing Chrome (Cmd+Q) first"
+else
+  CHROME_PAT="chrome|chromium|chromium-browse|google-chrome"
+  PGREP_MODE="-x"
+  QUIT_HINT="Quit existing Chrome (or 'pkill chrome') first"
+fi
+if pgrep "$PGREP_MODE" "$CHROME_PAT" >/dev/null; then
   echo "[designer-chrome] WARNING: Chrome is already running." >&2
   echo "                  If it's NOT a debug-mode Chrome, the launched window may not get the debug port." >&2
   echo "                  $QUIT_HINT, or accept the risk and continue." >&2


### PR DESCRIPTION
Follow-up to #150 and #110, both merged today.

#110 made `scripts/designer-chrome.sh` OS-aware but its Linux branch kept
`pgrep -f "chrome"` — the exact pattern #150 replaced in `cross-platform.ts`
for #114. It's non-fatal here (the script only prints a warning and continues),
so this is consistency rather than a second outage, but the two failure modes
are real on Linux:

- warns when only a `chromedriver` or a leftover `chrome_crashpad` is running
- stays silent when a real `chromium` is running, since `chromium` contains no
  `chrome` substring

Now uses `pgrep -x` against the same name alternation as `cross-platform.ts`,
including the truncated `chromium-browse` form. macOS keeps its full-path `-f`
match, unchanged.

Verified on `debian:stable-slim` + `procps`:

| running | before | after |
|---|---|---|
| only `chromedriver` | warns | silent |
| a real `chromium` | silent | warns |

`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)